### PR TITLE
[Neural Speed] Fix a blocker on Windows platforms

### DIFF
--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -18,13 +18,10 @@ import argparse
 from typing import List, Optional
 import subprocess
 from transformers import AutoTokenizer
+import neural_speed
 
 model_maps = {"gpt_neox": "gptneox", "llama2": "llama", "gpt_bigcode": "starcoder"}
 build_path = Path(Path(__file__).parent.absolute(), "../build/")
-
-
-def is_win():
-    return sys.platform.startswith('win')
 
 
 def main(args_in: Optional[List[str]] = None) -> None:
@@ -130,19 +127,8 @@ def main(args_in: Optional[List[str]] = None) -> None:
     args = parser.parse_args(args_in)
     print(args)
     model_name = model_maps.get(args.model_name, args.model_name)
-    if is_win():
-        path = Path(args.build_dir, "./Bin/Release/run_{}.exe".format(model_name))
-    else:
-        if args.one_click_run == "True":
-            import neural_speed
-            package_path = os.path.dirname(neural_speed.__file__)
-            path = Path(package_path, "./run_{}".format(model_name))
-        else:
-            path = Path(args.build_dir, "./bin/run_{}".format(model_name))
-
-    if not path.exists():
-        print("Please build graph first or select the correct model name.")
-        sys.exit(1)
+    package_path = os.path.dirname(neural_speed.__file__)
+    path = Path(package_path, "./run_{}".format(model_name))
 
     cmd = [path]
     cmd.extend(["--model", args.model])

--- a/scripts/quantize.py
+++ b/scripts/quantize.py
@@ -17,13 +17,10 @@ from pathlib import Path
 import argparse
 from typing import List, Optional
 import subprocess
+import neural_speed
 
 model_maps = {"gpt_neox": "gptneox", "llama2": "llama", "gpt_bigcode": "starcoder"}
 build_path = Path(Path(__file__).parent.absolute(), "../build/")
-
-
-def is_win():
-    return sys.platform.startswith('win')
 
 
 def str2bool(v):
@@ -100,19 +97,8 @@ def main(args_in: Optional[List[str]] = None) -> None:
     args = parser.parse_args(args_in)
 
     model_name = model_maps.get(args.model_name, args.model_name)
-    if is_win():
-        path = Path(args.build_dir, "./Bin/Release/quant_{}.exe".format(model_name))
-    else:
-        if args.one_click_run == "True":
-            import neural_speed
-            package_path = os.path.dirname(neural_speed.__file__)
-            path = Path(package_path, "./quant_{}".format(model_name))
-        else:
-            path = Path(args.build_dir, "./bin/quant_{}".format(model_name))
-    if not path.exists():
-        print(path)
-        print("Please build graph first or select the correct model name.")
-        sys.exit(1)
+    package_path = os.path.dirname(neural_speed.__file__)
+    path = Path(package_path, "./quant_{}".format(model_name))
 
     cmd = [path]
     cmd.extend(["--model_file", args.model_file])


### PR DESCRIPTION
## Type of Change

- Fix a blocker that prevents Neural Speed from running on Windows platforms.

## Description

- In your code, you look for the binary if it's a windows, but there is none since in the README we build Neural Speed with setup.py, and not with cmake anymore, so in any case whether it's Linux or Windows we are going to use the executable that can be found in the Neural Speed package.

## Expected Behavior & Potential Risk

- Completes the conversion, quantization and inference successfully.

## How has this PR been tested?

- Tested on my SPR workstation with Win11 OS, and it's working as expected.

## Dependency Change?

N/A