### PR TITLE
update profling log when NS_PROFILING is OFF

### DIFF
--- a/neural_speed/core/ne_layers.c
+++ b/neural_speed/core/ne_layers.c
@@ -10882,6 +10882,7 @@ void ne_graph_compute(struct ne_context* ctx, struct ne_cgraph* cgraph) {
 }
 
 void ne_graph_profiling(const struct ne_cgraph* cgraph) {
+#ifdef NS_PERF
   int64_t perf_total_per_op_us[NE_OP_COUNT] = {0};
 
   NE_PRINT("=== GRAPH Profiling ===\n");
@@ -10904,6 +10905,10 @@ void ne_graph_profiling(const struct ne_cgraph* cgraph) {
   }
   NE_PRINT("perf_total_per_op_us[%24s] = %7.3f ms\n", "INNER PRODUCT", (double)ip_duration / 1000.0);
   NE_PRINT("========================================\n");
+
+#else
+  NE_PRINT("\n[Warning] To collect profiling data, please recompile with NS_PROFILING=ON.\n");
+#endif
 }
 
 void ne_graph_reset(struct ne_cgraph* cgraph) {

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ def check_env_flag(name: str, default: bool = False) -> bool:
 
 NS_WITH_AVX2 = check_env_flag("NS_WITH_AVX2", 'avx512f' not in cpu_flags)
 """ Whether to limit the max ISA used to AVX2; otherwise AVX512 will be used; set to ON/OFF """
+NS_PROFILING_ENV = os.environ.get("NS_PROFILING", "OFF")
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 
@@ -93,7 +94,6 @@ class CMakeBuild(build_ext):
         extdir = ext_fullpath.parent.resolve()
 
         output_dir = f"{extdir}{os.sep}"
-        NS_PROFILING_ENV = os.environ.get("NS_PROFILING", "OFF")
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={output_dir}",
             f"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY={output_dir}",

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ class CMakeBuild(build_ext):
         extdir = ext_fullpath.parent.resolve()
 
         output_dir = f"{extdir}{os.sep}"
+        NS_PROFILING_ENV = os.environ.get("NS_PROFILING", "OFF")
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={output_dir}",
             f"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY={output_dir}",
@@ -104,6 +105,7 @@ class CMakeBuild(build_ext):
             f"-DNS_WITH_AVX2={'ON' if NS_WITH_AVX2 else 'OFF'}",
             f"-DNS_WITH_TESTS=OFF",
             f"-DNS_PYTHON_API=ON",
+            f"-DNS_PROFILING={NS_PROFILING_ENV}",
         ]
         if sys.platform == "linux":  # relative_rpath
             cmake_args.append('-DCMAKE_BUILD_RPATH=$ORIGIN/')


### PR DESCRIPTION
## Type of Change

feature or bug fix or documentation or others
API changed or not

## Description

when NS_PROFILING is OFF and NEURAL_SPEED_VERBOSE=0/2, will print warning instead of 0ms logs
`[Warning] To collect profiling data, please recompile with NS_PROFILING=ON.`

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
