### PR TITLE
check isa for UT, use OMP as default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ if (NS_BTLA_UT)
 endif()
 include(FindOpenMP)
 
+set(BTLA_USE_OPENMP ON)
 add_subdirectory(bestla)
 
 add_subdirectory(neural_speed)

--- a/bestla/bestla/ut/kernel_wrapper.cpp
+++ b/bestla/bestla/ut/kernel_wrapper.cpp
@@ -201,14 +201,16 @@ class UT_LayerNormalization {
  public:
   UT_LayerNormalization() {
     UT_START();
-    ut<float, BTLA_ISA::AVX512F>(4096, false, true, true);
-    ut<float, BTLA_ISA::AVX512F>(4096, false, false, false);
-    ut<float, BTLA_ISA::AVX512F>(111, false, true, true);
-    ut<float, BTLA_ISA::AVX512F>(111, true, true, true);
+    CheckISA(AVX2);
     ut<float, BTLA_ISA::AVX2>(4096, false, true, true);
     ut<float, BTLA_ISA::AVX2>(4096, false, false, false);
     ut<float, BTLA_ISA::AVX2>(111, false, true, true);
     ut<float, BTLA_ISA::AVX2>(111, true, true, true);
+    CheckISA(AVX512F);
+    ut<float, BTLA_ISA::AVX512F>(4096, false, true, true);
+    ut<float, BTLA_ISA::AVX512F>(4096, false, false, false);
+    ut<float, BTLA_ISA::AVX512F>(111, false, true, true);
+    ut<float, BTLA_ISA::AVX512F>(111, true, true, true);
   }
   template <typename T, BTLA_ISA ISA>
   void ut(int norm_size, bool simplified, bool hasscale, bool hasbias) {


### PR DESCRIPTION
## Type of Change

1. set OMP on  for bestla. 
2. Check AVX512F flag for LayerNormalization.

Perf on Ultra7-155H, Mistral-7B int4, group=-1, compute_dtype=int8

```
 Once we have made our plans,
 We can’t follow them.


model_print_timings:        load time =   100.93 ms
model_print_timings:      sample time =     8.00 ms /    16 runs   (    0.50 ms per token)
model_print_timings: prompt eval time =   100.82 ms /     2 tokens (   50.41 ms per token)
model_print_timings:        eval time =  1239.00 ms /    15 runs   (   82.60 ms per token)
model_print_timings:       total time =  1355.56 ms
========== eval time log of each prediction ==========
prediction   0, time: 100.82ms
prediction   1, time: 79.96ms
prediction   2, time: 81.61ms
prediction   3, time: 80.69ms
prediction   4, time: 81.98ms
prediction   5, time: 82.39ms
```