### PR TITLE
improve hardware-thread occupancy under large K-dim case

### DIFF
--- a/tests/integration/gemm/int4_dequantization_bias/main_dg2.cpp
+++ b/tests/integration/gemm/int4_dequantization_bias/main_dg2.cpp
@@ -19,7 +19,7 @@
 // #define UT_DEBUG 1
 using namespace gpu::xetla;
 //The number of times the kernel is executed
-constexpr int ITER = 100;
+constexpr int ITER = 1000;
 
 class test1 {
 public:
@@ -244,8 +244,8 @@ public:
     static constexpr size_t sg_k = 16;
     static constexpr size_t dequant_s = 64;
     static constexpr size_t num_buffer = 64;
-    static constexpr size_t local_kslicing = 4;
-    static constexpr size_t global_kslicing = 1;
+    static constexpr size_t local_kslicing = 8;
+    static constexpr size_t global_kslicing = 2;
     static constexpr mem_layout layout_a = mem_layout::row_major;
     static constexpr mem_layout layout_b = mem_layout::row_major;
     using data_type_a = fp16;
@@ -585,7 +585,7 @@ TYPED_TEST_P(dequantize_gemm_test, esimd) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(dequantize_gemm_test, esimd);
-using tests = ::testing::Types<qkv6>;
+using tests = ::testing::Types<qkv9, qkv6>;
 // using tests = ::testing::Types<qkv1, qkv2, qkv3, qkv4, qkv5, qkv6, qkv7, qkv8,
 //         qkv9, qkv10>;
 

--- a/tests/integration/gemm/int4_dequantization_bias/main_dg2.cpp
+++ b/tests/integration/gemm/int4_dequantization_bias/main_dg2.cpp
@@ -350,7 +350,7 @@ void dequantize_gemm_run(int iter) {
     using tile_shape = xetla::group::tile_shape_t<wg_tile_n, wg_tile_m,
             sg_tile_n, sg_tile_m>;
     static constexpr uint32_t periodic_sync_interval = 0;
-    static constexpr uint32_t prefetch_distance = 0;
+    static constexpr uint32_t prefetch_distance = 1;
 
     using mem_desc_a_t = xetla::mem_desc_t<data_type_a, mem_layout::row_major,
             mem_space::global, DEVICE_MEM_ALIGNMENT / sizeof(data_type_a)>;


### PR DESCRIPTION
## Type of Change

feature or bug fix or documentation or others: bug
API changed or not:no

## Description
gemm shape: 1x4096x11008 (mxnxk)
thread occupancy: 15% => 75%
detail description 
Issues: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
