### PR TITLE
[Enhence] Add the feature of Mistral online loading from the HF

### DIFF
--- a/neural_speed/convert/convert_llama.py
+++ b/neural_speed/convert/convert_llama.py
@@ -1446,8 +1446,6 @@ def main(args_in: Optional[List[str]] = None) -> None:
             model = AutoModel.from_pretrained(args.model, low_cpu_mem_usage=True, trust_remote_code=True)
             tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
             cache_path = Path(tokenizer.vocab_file).parent
-
-            model_plus = load_some_model(cache_path)
             args.model = cache_path
 
         model_plus = load_some_model(args.model)

--- a/neural_speed/convert/convert_mistral.py
+++ b/neural_speed/convert/convert_mistral.py
@@ -36,6 +36,7 @@ from typing import (IO, TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Lite
 
 import numpy as np
 from sentencepiece import SentencePieceProcessor  # type: ignore
+from transformers import AutoModel, AutoModelForCausalLM, AutoTokenizer, AutoConfig
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
@@ -1306,6 +1307,15 @@ def main(args_in: Optional[List[str]] = None) -> None:
         OutputFile.write_vocab_only(outfile, vocab)
         print(f"Wrote {outfile}")
     else:
+        if Path(args.model).is_dir():
+            print("Loadding the model from the local path.")
+        else:
+            print("Loadding the model from HF.")
+            model = AutoModel.from_pretrained(args.model, low_cpu_mem_usage=True, trust_remote_code=True)
+            tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+            cache_path = Path(tokenizer.vocab_file).parent
+            args.model = cache_path
+
         model_plus = load_some_model(args.model)
         if args.dump:
             do_dump_model(model_plus)


### PR DESCRIPTION
## Type of Change

New Feature.

Related PR: https://github.com/intel/neural-speed/pull/93

## Description

[Enhence] Add the feature of Mistral online loading from the HF

validated models:
* Intel/neural-chat-7b-v3-1
* [mistralai/Mistral-7B-v0.1 · Hugging Face](https://huggingface.co/mistralai/Mistral-7B-v0.1)

```python
from transformers import AutoTokenizer, TextStreamer
from intel_extension_for_transformers.transformers import AutoModelForCausalLM
model_name = "Intel/neural-chat-7b-v3-1"     # Hugging Face model_id or local model
#model_name = "/home/zhenzhong/model/neural-chat-7b-v3-1"
prompt = "Once upon a time, there existed a little girl,"

tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
inputs = tokenizer(prompt, return_tensors="pt").input_ids
streamer = TextStreamer(tokenizer)

model = AutoModelForCausalLM.from_pretrained(model_name, load_in_4bit=True)
outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)
```

Inference screenshot:
![image](https://github.com/intel/neural-speed/assets/109137058/0e9ea302-3e8e-48a4-8852-ce3a3655bca7)

Online loading screenshot:
![image](https://github.com/intel/neural-speed/assets/109137058/4ee5a051-f14b-4dfe-9e51-b79a12ffcbb9)


## Expected Behavior & Potential Risk

N/A

## How has this PR been tested?

Manually

## Dependency Change?

N/A
