### PR TITLE
[BesTLA] AVX2: Use loaded registers of B.

### DIFF
--- a/bestla/bestla/bestla_gemm.h
+++ b/bestla/bestla/bestla_gemm.h
@@ -2716,7 +2716,7 @@ class AvxvnniN8P4 : protected bestla::xbyak::JitAvxvnni {
           vpbroadcastd(vreg_t(AReg), ptr[reg_tmp1]);
           add(reg_tmp1, reg_astride);
           for (int i = 0; i < NRegs; i++) {
-            vpdpbusds_(vreg_t(CReg + mm * NRegs + i), vreg_t(AReg), ptr[reg_matBptr + kk * BKStepSize + i * VecBytes]);
+            vpdpbusds_(vreg_t(CReg + mm * NRegs + i), vreg_t(AReg), vreg_t(BReg + i));
           }
         }
       }


### PR DESCRIPTION
## Type of Change

Small performance patch for AVX2.

## Description

It appears the B registers are loaded, but the FMA uses the same pointers for B, rather than the registers that have been loaded?

## Expected Behavior & Potential Risk

On SPR, with AVX512/AMX disabled, I see a performance improvement for prefill and decode:
```
NEURAL_SPEED_VERBOSE=0 taskset --cpu-list 1 build/bin/run_llama -m llama2.ne.weight-int8.group-128.compute-int8.avx2.bin --seed 1 -t 1 -n 8 -c 1024 -b 1024 --memory-auto -p 'Ha ha, well, a woodchuck would certainly be able to chuck some wood! But if you’re looking for a more straightforward answer, it depends on the size of the woodchuck and the type of wood. A small woodchuck might only be able to move a few sticks of firewood at a time, while a larger one might be able to move a whole log or two. Is'
...
<before PR>
========== eval time log of each prediction ==========
prediction   0, time: 5483.49ms
prediction   1, time: 1171.33ms
prediction   2, time: 1170.22ms
prediction   3, time: 1169.63ms
prediction   4, time: 1170.13ms
prediction   5, time: 1169.81ms
prediction   6, time: 1170.32ms
prediction   7, time: 1170.42ms
<after PR>
========== eval time log of each prediction ==========
prediction   0, time: 4706.76ms
prediction   1, time: 1127.17ms
prediction   2, time: 1126.01ms
prediction   3, time: 1125.48ms
prediction   4, time: 1126.33ms
prediction   5, time: 1125.82ms
prediction   6, time: 1126.05ms
prediction   7, time: 1128.50ms
```

## How has this PR been tested?

See above.

## Dependency Change?

None.
