### PR TITLE
[Bug fixed] Rename tuple to Tuple to be compatible with python3.8

### DIFF
--- a/neural_speed/convert/common.py
+++ b/neural_speed/convert/common.py
@@ -195,18 +195,18 @@ class BpeVocab:
         self.vocab_size = self.vocab_size_base + len(self.added_tokens_list)
         self.fname_tokenizer = fname_tokenizer
 
-    def bpe_tokens(self) -> Iterable[tuple[bytes, float]]:
+    def bpe_tokens(self) -> Iterable[Tuple[bytes, float]]:
         reverse_vocab = {id: encoded_tok for encoded_tok, id in self.vocab.items()}
 
         for i, _ in enumerate(self.vocab):
             yield reverse_vocab[i], 0.0
 
-    def added_tokens(self) -> Iterable[tuple[bytes, float]]:
+    def added_tokens(self) -> Iterable[Tuple[bytes, float]]:
         for text in self.added_tokens_list:
             score = -1000.0
             yield text.encode("utf-8"), score
 
-    def all_tokens(self) -> Iterable[tuple[bytes, float]]:
+    def all_tokens(self) -> Iterable[Tuple[bytes, float]]:
         yield from self.bpe_tokens()
         yield from self.added_tokens()
 


### PR DESCRIPTION
## Type of Change

[Bug fixed] Rename tuple to Tuple to be compatible with python3.8

## Description

[Bug fixed] Rename tuple to Tuple to be compatible with python3.8

## Expected Behavior & Potential Risk

N/A

## How has this PR been tested?

![image](https://github.com/intel/neural-speed/assets/109137058/b5f8093c-404c-4c8a-a871-348d7386fd68)


## Dependency Change?

N/A
