### PR TITLE
Add dpas attr, refine mma, load, store attr

### DIFF
--- a/include/common/core/arch_config.hpp
+++ b/include/common/core/arch_config.hpp
@@ -27,11 +27,14 @@ namespace gpu::xetla {
 /// @{
 
 template <msg_type message_type, gpu_arch arch_tag>
-struct load_store_attr_t {};
+struct load_store_attr_t {
+  static constexpr bool has_hw_block_2d = false;
+};
 
 template <>
 struct load_store_attr_t<msg_type::block_2d, gpu_arch::XeHpc> {
   /// HW limitation checks https://gfxspecs.intel.com/Predator/Home/Index/55490
+  static constexpr bool has_hw_block_2d = true;
   static constexpr uint32_t max_load_height_in_elem = 32;
   static constexpr uint32_t max_load_width_in_bytes = 64;
   static constexpr uint32_t max_trans_load_width_in_bytes = 32;
@@ -53,6 +56,7 @@ struct load_store_attr_t<msg_type::block_2d, gpu_arch::XeHpc> {
 template <msg_type message_type, gpu_arch arg_tag>
 struct client_load_store_attr_base_t {
   /// HW limitation checks https://gfxspecs.intel.com/Predator/Home/Index/55490
+  static constexpr bool has_hw_block_2d = false;
   static constexpr uint32_t max_load_height_in_elem = 32;
   static constexpr uint32_t max_load_width_in_bytes = 64;
   static constexpr uint32_t max_trans_load_width_in_bytes = 32;
@@ -84,60 +88,102 @@ struct load_store_attr_t<msg_type::block_2d, gpu_arch::XeLpg>
           gpu_arch::XeLpg> {};
 
 template <gpu_arch arch_tag>
+inline constexpr bool arch_has_2d_load_store =
+            load_store_attr_t<msg_type::block_2d, arch_tag>::has_hw_block_2d;
+
+template <gpu_arch arch_tag>
 struct load_store_attr_t<msg_type::block_1d, arch_tag> {
-  static constexpr uint32_t max_load_vec_len = 64;
-  static constexpr uint32_t max_store_vec_len = 64;
-};
-
-template <gpu_arch arch_tag>
-struct mma_attr_t {};
-
-template <gpu_arch arch_tag>
-struct client_mma_atr_base_t {
-  static constexpr uint32_t mma_m_in_elem = 8;
-  static constexpr uint32_t mma_n_in_elem = 8;
-  static constexpr uint32_t mma_k_in_bytes = 32;
+  static constexpr uint32_t max_load_vec_len = 32;
+  static constexpr uint32_t max_store_vec_len = 32;
+  static constexpr uint32_t max_prefetch_vec_len = 32;
 };
 
 template <>
-struct mma_attr_t<gpu_arch::XeHpc> {
-  static constexpr uint32_t mma_m_in_elem = 8;
+struct load_store_attr_t<msg_type::block_1d, gpu_arch::XeHpc> {
+  static constexpr uint32_t max_load_vec_len = 64;
+  static constexpr uint32_t max_store_vec_len = 64;
+  static constexpr uint32_t max_prefetch_vec_len = 64;
+};
+
+struct dpas_attr_base_t {
+  static constexpr bool has_xmx = true;
+  static constexpr uint32_t systolic_depth = 8;
+  static constexpr uint32_t rcount_max = 8;
+  static constexpr uint32_t op_per_channel_bits = 32;
+  static constexpr uint32_t op_per_channel_bytes = (op_per_channel_bits >> 3);
+  static constexpr uint32_t op_per_channel_max = 8;
+};
+
+template <gpu_arch arch_tag>
+struct dpas_attr_t {
+  static constexpr bool has_xmx = false;
+};
+
+template <>
+struct dpas_attr_t<gpu_arch::XeHpc> : public dpas_attr_base_t {
+  static constexpr uint32_t n_fixed_limit = 16;
+};
+
+template <>
+struct dpas_attr_t<gpu_arch::XeHpg> : public dpas_attr_base_t {
+  static constexpr uint32_t n_fixed_limit = 8;
+};
+
+template <gpu_arch arch_tag>
+inline constexpr bool arch_has_xmx = dpas_attr_t<arch_tag>::has_xmx;
+
+template <gpu_arch arch_tag>
+struct fpu_attr_t {
+  static constexpr bool has_fpu = true;
+};
+
+template <gpu_arch arch_tag>
+inline constexpr bool arch_has_fpu = fpu_attr_t<arch_tag>::has_fpu;
+
+template <grf_mode grf_num_mode>
+struct register_nums_t {
+  static constexpr uint32_t register_nums =
+      (grf_num_mode == grf_mode::normal) ? 128 : 256;
+  static constexpr uint32_t acc_register_nums =
+      (grf_num_mode == grf_mode::normal) ? 4 : 8;
+};
+
+template <gpu_arch arch_tag>
+struct register_bytes_t {
+  static constexpr uint32_t reg_in_bytes = 64;
+};
+
+template <grf_mode grf_num_mode, gpu_arch arch_tag>
+struct register_attr_t {
+  static constexpr uint32_t reg_in_bytes =
+      register_bytes_t<arch_tag>::reg_in_bytes;
+  static constexpr uint32_t register_nums =
+      register_nums_t<grf_num_mode>::register_nums;
+  static constexpr uint32_t acc_register_nums =
+      register_nums_t<grf_num_mode>::acc_register_nums;
+  static constexpr uint32_t acc_reg_in_bytes = acc_register_nums * reg_in_bytes;
+  static constexpr uint32_t grf_in_bytes = register_nums * reg_in_bytes;
+};
+
+template <gpu_arch arch_tag, uint32_t m, class enable = void>
+struct mma_attr_t {};
+
+template <gpu_arch arch_tag, uint32_t m>
+struct mma_attr_t<arch_tag, m, std::enable_if_t<arch_has_xmx<arch_tag>>> {
+  using dpas_attr = dpas_attr_t<arch_tag>;
+  static constexpr uint32_t mma_m_in_elem =
+      (m > dpas_attr::rcount_max) ? dpas_attr::rcount_max : m;
+  static constexpr uint32_t mma_n_in_elem = dpas_attr::n_fixed_limit;
+  static constexpr uint32_t mma_k_in_bytes =
+      dpas_attr::systolic_depth * dpas_attr::op_per_channel_bytes;
+};
+
+template <gpu_arch arch_tag, uint32_t m>
+struct mma_attr_t<arch_tag, m, std::enable_if_t<!arch_has_xmx<arch_tag>>> {
+  static constexpr uint32_t mma_m_in_elem = (m > 8) ? 8 : m;
   static constexpr uint32_t mma_n_in_elem = 16;
   static constexpr uint32_t mma_k_in_bytes = 32;
 };
-
-template <>
-struct mma_attr_t<gpu_arch::XeHpg>
-    : public client_mma_atr_base_t<gpu_arch::XeHpg> {};
-
-template <grf_mode grf_num_mode, gpu_arch arch_tag>
-struct register_attr_t {};
-
-template <grf_mode grf_num_mode, gpu_arch arch_tag>
-struct client_register_attr_base_t {
-  static constexpr uint32_t acc_reg_in_bytes =
-      (grf_num_mode == grf_mode::normal) ? 4 * 64 : 8 * 64;
-  static constexpr uint32_t grf_in_bytes =
-      (grf_num_mode == grf_mode::normal) ? 128 * 64 : 256 * 64;
-  static constexpr uint32_t reg_in_bytes = 64;
-};
-
-template <grf_mode grf_num_mode>
-struct register_attr_t<grf_num_mode, gpu_arch::XeHpc> {
-  static constexpr uint32_t acc_reg_in_bytes =
-      (grf_num_mode == grf_mode::normal) ? 4 * 64 : 8 * 64;
-  static constexpr uint32_t grf_in_bytes =
-      (grf_num_mode == grf_mode::normal) ? 128 * 64 : 256 * 64;
-  static constexpr uint32_t reg_in_bytes = 64;
-};
-
-template <grf_mode grf_num_mode>
-struct register_attr_t<grf_num_mode, gpu_arch::XeHpg>
-    : public client_register_attr_base_t<grf_num_mode, gpu_arch::XeHpg> {};
-
-template <grf_mode grf_num_mode>
-struct register_attr_t<grf_num_mode, gpu_arch::XeLpg>
-    : public client_register_attr_base_t<grf_num_mode, gpu_arch::XeLpg> {};
 
 template <gpu_arch arch_tag>
 struct arch_attr_t {};
@@ -145,12 +191,12 @@ struct arch_attr_t {};
 template <gpu_arch arch_tag>
 struct client_arch_attr_base_t {
   template <msg_type message_type = msg_type::block_2d>
-  using load_store_attr = load_store_attr_t<message_type, gpu_arch::XeHpg>;
+  using load_store_attr = load_store_attr_t<message_type, arch_tag>;
 
-  template <grf_mode grf_num_mode = grf_mode::double_grf>
-  using register_attr = register_attr_t<grf_num_mode, gpu_arch::XeHpg>;
+  template <grf_mode grf_num_mode = grf_mode::normal>
+  using register_attr = register_attr_t<grf_num_mode, arch_tag>;
 
-  using mma_attr = mma_attr_t<gpu_arch::XeHpg>;
+  using dpas_attr = dpas_attr_t<arch_tag>;
 
   static constexpr uint32_t max_wg_num = 64;
   static constexpr uint32_t local_mem_size = 64 * 1024;
@@ -164,7 +210,7 @@ struct arch_attr_t<gpu_arch::XeHpc> {
   template <grf_mode grf_num_mode = grf_mode::double_grf>
   using register_attr = register_attr_t<grf_num_mode, gpu_arch::XeHpc>;
 
-  using mma_attr = mma_attr_t<gpu_arch::XeHpc>;
+  using dpas_attr = dpas_attr_t<gpu_arch::XeHpc>;
 
   static constexpr uint32_t max_wg_num = 64;
   static constexpr uint32_t local_mem_size = 128 * 1024;

--- a/include/common/core/common_types.hpp
+++ b/include/common/core/common_types.hpp
@@ -22,12 +22,6 @@
 
 namespace gpu::xetla {
 enum class gpu_arch : uint8_t { XeLpg = 0, XeHpg = 1, XeHpc = 2 };
-inline constexpr bool arch_has_xmx(gpu_arch arch) {
-  return arch >= gpu_arch::XeHpg;
-}
-inline constexpr bool arch_has_2d_load_store(gpu_arch arch) {
-  return arch >= gpu_arch::XeHpc;
-}
 
 enum class grf_mode : uint8_t { normal = 0, double_grf = 1 };
 

--- a/include/group/gemm/compute_policy.hpp
+++ b/include/group/gemm/compute_policy.hpp
@@ -46,77 +46,44 @@ struct compute_policy_default_xmx<
     compute_attr_,
     perf_tuning_knob_,
     arch_tag_,
-    std::enable_if_t<arch_has_xmx(arch_tag_)>> {
-  using compute_attr = compute_attr_;
-  using perf_tuning_knob = perf_tuning_knob_;
-  static constexpr int k_stride = perf_tuning_knob::k_stride;
-  static constexpr int stages = perf_tuning_knob::stages;
-  static constexpr int sync_freq = perf_tuning_knob::sync_freq;
+    std::enable_if_t<arch_has_xmx<arch_tag_>>> {
   static constexpr gpu_arch arch_tag = arch_tag_;
+
+  using compute_attr = compute_attr_;
   using dtype_mma_acc = typename compute_attr::dtype_acc;
   using dtype_mma_a = typename compute_attr::dtype_a;
   using dtype_mma_b = typename compute_attr::dtype_b;
 
-  static constexpr uint32_t block_bytes_x_a = 32;
+  using perf_tuning_knob = perf_tuning_knob_;
+  static constexpr int stages = perf_tuning_knob::stages;
+  static constexpr int sync_freq = perf_tuning_knob::sync_freq;
+  static constexpr int k_stride = perf_tuning_knob::k_stride;
+
+  static constexpr uint32_t block_size_y_a = 16;
+  using mma_attr = mma_attr_t<arch_tag, block_size_y_a>;
+  static constexpr uint32_t block_bytes_x_a = mma_attr::mma_k_in_bytes;
   static constexpr uint32_t block_size_x_a =
       block_bytes_x_a / sizeof(dtype_mma_a);
-  static constexpr uint32_t block_size_y_a = 16;
 
-  static constexpr uint32_t block_size_x_b =
-      arch_attr_t<arch_tag>::mma_attr::mma_n_in_elem;
-  static constexpr uint32_t block_bytes_y_b = 32;
-  static constexpr uint32_t block_size_y_b =
-      block_bytes_y_b / sizeof(dtype_mma_b);
-  static_assert(
-      block_size_x_a == block_size_y_b,
-      "mat_a x need to match with mat_b y");
+  static constexpr uint32_t block_size_x_b = mma_attr::mma_n_in_elem;
+  static constexpr uint32_t block_size_y_b = block_size_x_a;
+  static constexpr uint32_t block_bytes_y_b =
+      block_size_x_a * sizeof(dtype_mma_b);
 };
 
 /// @brief Compute policy for unaligned shape and xmx engine.
 /// @tparam compute_attr_ Is compute-related attributes.
 /// @tparam perf_tuning_knob_ Is performance-related knobs.
 /// @tparam arch_tag_ Is the HW architecture.
-template <
-    typename compute_attr_,
-    typename perf_tuning_knob_,
-    gpu_arch arch_tag_ = gpu_arch::XeHpc,
-    typename enable = void>
-struct compute_policy_unaligned_xmx {};
-
 /// @brief Specialized for Xe architecture.
 template <
     typename compute_attr_,
     typename perf_tuning_knob_,
     gpu_arch arch_tag_>
-struct compute_policy_unaligned_xmx<
-    compute_attr_,
-    perf_tuning_knob_,
-    arch_tag_,
-    std::enable_if_t<arch_has_xmx(arch_tag_)>> {
-  using compute_attr = compute_attr_;
-  using perf_tuning_knob = perf_tuning_knob_;
-  static constexpr int k_stride = perf_tuning_knob::k_stride;
-  static constexpr int stages = perf_tuning_knob::stages;
-  static constexpr int sync_freq = perf_tuning_knob::sync_freq;
-  static constexpr gpu_arch arch_tag = arch_tag_;
-  using dtype_mma_acc = typename compute_attr::dtype_acc;
-  using dtype_mma_a = typename compute_attr::dtype_a;
-  using dtype_mma_b = typename compute_attr::dtype_b;
-
-  static constexpr uint32_t block_bytes_x_a = 32;
-  static constexpr uint32_t block_size_x_a =
-      block_bytes_x_a / sizeof(dtype_mma_a);
-  static constexpr uint32_t block_size_y_a = 16;
-
-  static constexpr uint32_t block_size_x_b =
-      arch_attr_t<arch_tag>::mma_attr::mma_n_in_elem;
-  static constexpr uint32_t block_bytes_y_b = 32;
-  static constexpr uint32_t block_size_y_b =
-      block_bytes_y_b / sizeof(dtype_mma_b);
-  static_assert(
-      block_size_x_a == block_size_y_b,
-      "mat_a x need to match with mat_b y");
-};
+struct compute_policy_unaligned_xmx : public compute_policy_default_xmx<
+                                          compute_attr_,
+                                          perf_tuning_knob_,
+                                          arch_tag_> {};
 
 /// @brief Compute policy for fpu engine.
 /// @tparam compute_attr_ Is compute-related attributes.
@@ -138,23 +105,25 @@ struct compute_policy_default_fpu<
     compute_attr_,
     perf_tuning_knob_,
     arch_tag_,
-    std::enable_if_t<(arch_tag_ <= gpu_arch::XeHpc)>> {
-  using compute_attr = compute_attr_;
-  using perf_tuning_knob = perf_tuning_knob_;
-  static constexpr int k_stride = perf_tuning_knob::k_stride;
-  static constexpr int stages = perf_tuning_knob::stages;
-  static constexpr int sync_freq = perf_tuning_knob::sync_freq;
+    std::enable_if_t<arch_has_fpu<arch_tag_>>> {
   static constexpr gpu_arch arch_tag = arch_tag_;
 
+  using compute_attr = compute_attr_;
   using dtype_mma_acc = typename compute_attr::dtype_acc;
   using dtype_mma_a = typename compute_attr::dtype_a;
   using dtype_mma_b = typename compute_attr::dtype_b;
 
+  using perf_tuning_knob = perf_tuning_knob_;
+  static constexpr int stages = perf_tuning_knob::stages;
+  static constexpr int sync_freq = perf_tuning_knob::sync_freq;
+  static constexpr int k_stride = perf_tuning_knob::k_stride;
+
+  static constexpr uint32_t block_size_y_a =
+      arch_tag_ == gpu_arch::XeLpg ? 8 : 16;
   static constexpr uint32_t block_bytes_x_a = 32;
   static constexpr uint32_t block_size_x_a =
       block_bytes_x_a / sizeof(dtype_mma_a);
-  static constexpr uint32_t block_size_y_a =
-      arch_tag_ == gpu_arch::XeLpg ? 8 : 16;
+
   static constexpr uint32_t block_bytes_x_b =
       arch_tag_ == gpu_arch::XeLpg ? 32 : 64;
   static constexpr uint32_t block_size_x_b =

--- a/include/group/gemm/impl/default_fpu_xe.hpp
+++ b/include/group/gemm/impl/default_fpu_xe.hpp
@@ -42,7 +42,7 @@ class gemm_t<
     mem_desc_a_t_, // memory attribute of matA
     mem_desc_b_t_, // memory attribute of matB
     pre_processing_t_, // pre_processing functor
-    std::enable_if_t<(arch_tag_ <= gpu_arch::XeHpc)>> {
+    std::enable_if_t<arch_has_fpu<arch_tag_>>> {
  public:
   using mem_desc_a_t = mem_desc_a_t_;
   using mem_desc_b_t = mem_desc_b_t_;

--- a/include/group/gemm/impl/default_xmx_xe.hpp
+++ b/include/group/gemm/impl/default_xmx_xe.hpp
@@ -42,7 +42,7 @@ class gemm_t<
     mem_desc_a_t_, // memory attribute of matA
     mem_desc_b_t_, // memory attribute of matB
     pre_processing_t_, // pre_processing functor
-    std::enable_if_t<arch_has_xmx(arch_tag_)>> {
+    std::enable_if_t<arch_has_xmx<arch_tag_>>> {
  public:
   using mem_desc_a_t = mem_desc_a_t_;
   using mem_desc_b_t = mem_desc_b_t_;
@@ -72,8 +72,8 @@ class gemm_t<
   using dtype_mma_a = typename compute_policy::dtype_mma_a;
   using dtype_mma_b = typename compute_policy::dtype_mma_b;
 
-  using check_dtype = group::gemm<gpu_arch::XeHpc>::default_xmx::
-      check_dtype_default<dtype_a, dtype_b, dtype_mma_a, dtype_mma_b>;
+  using check_dtype = group::gemm<arch_tag>::default_xmx::
+      template check_dtype_default<dtype_a, dtype_b, dtype_mma_a, dtype_mma_b>;
 
   /******** set memory attribute **********/
   static constexpr mem_space mem_space_a = mem_desc_a_t::space;
@@ -87,7 +87,7 @@ class gemm_t<
       is_col_major_b ? tdesc_update_dir::x_dir : tdesc_update_dir::y_dir;
 
   using check_memory =
-      group::gemm<gpu_arch::XeHpc>::default_xmx::check_memory_default<
+      group::gemm<arch_tag>::default_xmx::template check_memory_default<
           mem_layout_a,
           mem_layout_b,
           mem_space_a,
@@ -103,6 +103,7 @@ class gemm_t<
   static constexpr uint32_t tile_size_y_b = k_stride;
   static constexpr uint32_t tile_size_x_c = sg_tile_n;
   static constexpr uint32_t tile_size_y_c = sg_tile_m;
+
   static constexpr uint32_t block_size_x_a = compute_policy::block_size_x_a;
   static constexpr uint32_t block_size_y_a =
       (compute_policy::block_size_y_a > tile_size_y_a)
@@ -112,7 +113,7 @@ class gemm_t<
   static constexpr uint32_t block_size_y_b = compute_policy::block_size_y_b;
 
   using check_tile_size =
-      group::gemm<gpu_arch::XeHpc>::default_xmx::check_tile_size_default<
+      group::gemm<arch_tag>::default_xmx::template check_tile_size_default<
           dtype_mma_a,
           tile_size_x_a,
           tile_size_y_a,

--- a/include/group/gemm/impl/unaligned_xmx_xe.hpp
+++ b/include/group/gemm/impl/unaligned_xmx_xe.hpp
@@ -43,7 +43,7 @@ class gemm_t<
     mem_desc_a_t_, // memory attribute of matA
     mem_desc_b_t_, // memory attribute of matB
     pre_processing_t_, // pre_processing functor
-    std::enable_if_t<(arch_tag_ <= gpu_arch::XeHpc)>> {
+    std::enable_if_t<arch_has_xmx<arch_tag_>>> {
  public:
   using mem_desc_a_t = mem_desc_a_t_;
   using mem_desc_b_t = mem_desc_b_t_;
@@ -61,7 +61,7 @@ class gemm_t<
   static constexpr uint32_t wg_size_y = tile_shape::wg_size_y;
   using work_group_t = typename tile_shape::work_group_t;
 
-  constexpr static gpu_arch arch_tag = compute_policy::arch_tag;
+  constexpr static gpu_arch arch_tag = arch_tag_;
 
   static constexpr mem_layout mem_layout_a = mem_desc_a_t::layout;
   static constexpr mem_layout mem_layout_b = mem_desc_b_t::layout;

--- a/include/subgroup/tile/impl/fma_xe.hpp
+++ b/include/subgroup/tile/impl/fma_xe.hpp
@@ -37,7 +37,7 @@ struct tile_mma_t<
     matA_t_,
     mma_engine::fpu,
     arch_tag_,
-    std::enable_if_t<(arch_tag_ <= gpu_arch::XeHpc)>> {
+    std::enable_if_t<arch_has_fpu<arch_tag_>>> {
   using matA_t = matA_t_;
   using matB_t = matB_t_;
   using matSrc_t = matAcc_src_t_;

--- a/include/subgroup/tile/impl/mma_xe.hpp
+++ b/include/subgroup/tile/impl/mma_xe.hpp
@@ -38,7 +38,7 @@ struct tile_mma_t<
     matA_t_,
     mma_engine::xmx,
     arch_tag_,
-    std::enable_if_t<arch_has_xmx(arch_tag_)>> {
+    std::enable_if_t<arch_has_xmx<arch_tag_>>> {
   using matA_t = matA_t_;
   using matB_t = matB_t_;
   using matSrc_t = matAcc_src_t_;
@@ -47,8 +47,6 @@ struct tile_mma_t<
   using dtype_b = typename matB_t::dtype;
   using dtype_src = typename matSrc_t::dtype;
   using dtype_dst = typename matDst_t::dtype;
-
-  using mma_attr = typename arch_attr_t<arch_tag_>::mma_attr;
 
   static constexpr uint32_t a_tile_size_y = matA_t::tile_size_y;
   static constexpr uint32_t a_tile_size_x = matA_t::tile_size_x;
@@ -104,8 +102,10 @@ struct tile_mma_t<
   static constexpr int32_t num_block_m = matDst_t::num_block_y;
   static constexpr int32_t num_block_k = tile_size_k / block_size_k;
 
+  using mma_attr = mma_attr_t<arch_tag_, a_block_size_y>;
   static constexpr int32_t mma_m = mma_attr::mma_m_in_elem;
   static constexpr int32_t mma_k = mma_attr::mma_k_in_bytes / sizeof(uint32_t);
+
   static_assert(
       tile_size_m % mma_m == 0,
       "tile_size_m shoud be a multiple of mma_m");


### PR DESCRIPTION
## Type of Change

Add dpas attribution and refine mma, load, store attribution and related template functions

## Test
1) compilation build passed on bothe DG2 and PVC machine
2) tests/integration/gemm/int4_dequantization_bias, gemm_client_int4_dequantization_bias all test cases passed on DG2 and PVC machine