### PR TITLE
[BesTLA] Support int7 for kernels and models

### DIFF
--- a/bestla/README.md
+++ b/bestla/README.md
@@ -27,6 +27,7 @@ BesTLA provides weight-only linear computational capabilities for LLM inference.
 | INT2                   | INT8 / BF16 / FP32 |    BF16 / FP32    | sym / asym |
 | INT5                   | INT8 / BF16 / FP32 |    BF16 / FP32    | sym / asym |
 | INT6                   | INT8 / BF16 / FP32 |    BF16 / FP32    | sym / asym |
+| INT7                   | INT8 / BF16 / FP32 |    BF16 / FP32    | sym / asym |
 | FP8 (E4M3, E5M2)       |    BF16 / FP32     | FP32 / FP8 (E8M0) |    sym     |
 | FP4 (E2M1)             |    BF16 / FP32     |    BF16 / FP32    |    sym     |
 | NF4                    |    BF16 / FP32     |    BF16 / FP32    |    sym     |
@@ -76,7 +77,7 @@ mkdir build
 cd build
 cmake .. -DBTLA_UT_BENCHMARK=ON -DBTLA_UT_ALL=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build . -j
-./bestla_benchmark
+./bin/bestla_benchmark
 ```
 
 More template usages, please refer code in [bestla_benchmark](bestla/ut/bestla_benchmark.cpp)

--- a/bestla/bestla/kernel_avx2.h
+++ b/bestla/bestla/kernel_avx2.h
@@ -550,7 +550,7 @@ static inline BTLA_CODE decompress_kblock_s4_s8(utils::int4x2* srcptr, int8_t* z
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::int4x2 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -764,7 +764,7 @@ static inline BTLA_CODE decompress_kblock_s2_s8(utils::bit2x4* bit2ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -1022,7 +1022,7 @@ static inline BTLA_CODE decompress_kblock_s3_s8(utils::bit2x4* bit2ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -1276,7 +1276,7 @@ static inline BTLA_CODE decompress_kblock_s5_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -1590,9 +1590,9 @@ static inline BTLA_CODE decompress_kblock_s7_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset,
                                                 int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
-                                    int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
-                                    int row, int8_t* tmp, size_t tmpsize);
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr,
+                                    int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp, int n_offset,
+                                    int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
       if constexpr (PackRow == 1) {
@@ -1853,7 +1853,7 @@ static inline BTLA_CODE decompress_kblock_s6_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;

--- a/bestla/bestla/kernel_avx2.h
+++ b/bestla/bestla/kernel_avx2.h
@@ -6119,7 +6119,7 @@ static inline BTLA_CODE gemv_7bit_s8s8_fp32(const utils::GemvParamA& A, const ut
   for (int i = 0; i < NReg * MReg; i++) {
     acc[i] = _mm256_setzero_ps();
   }
-  int constexpr FullRange = 1 << (6 - 1);
+  int constexpr FullRange = 1 << (7 - 1);
   uint32_t mask = 0x0f0f0f0f;
   auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
   auto vbias = _mm256_set1_epi8(FullRange);

--- a/bestla/bestla/kernel_avx2.h
+++ b/bestla/bestla/kernel_avx2.h
@@ -3777,6 +3777,117 @@ static inline BTLA_CODE gemv_6bit_fp32_fp32(const float* A, int lda, const utils
   return BTLA_CODE::Success;
 }
 
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_7bit_fp32_fp32(const float* A, int lda, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b4ptr = (utils::bit4x2*)B.b4ptr;
+  auto b2ptr = (utils::bit2x4*)B.b2ptr;
+  auto b1ptr = (utils::bit1x8*)B.b1ptr;
+
+  int blks = k / blocksize;
+  int constexpr NReg = NTILE / 8;
+  int constexpr MReg = MTILE;
+  // Initialize accumulator with zeros
+  __m256 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm256_setzero_ps();
+  }
+
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm256_set1_epi8(FullRange);
+
+  uint32_t mask0 = 0x03030303;
+  auto vmask0 = _mm256_set1_epi32(*(int32_t*)&mask0);
+  auto vshift_y = _mm256_set_epi32(6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm256_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+  int constexpr KTILE = 1;
+  for (int ib = 0; ib < blks; ib += 1) {
+    auto bsptr = B.sptr + ib * B.ldzp;
+
+    __m256 acc_loc[NReg * MReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      acc_loc[i] = _mm256_setzero_ps();
+    }
+    int constexpr Unroll = 4;
+    assert((blocksize % 4) == 0);
+    assert(tmpsize >= NTILE * Unroll);
+
+    if (B.zpptr) {
+      __m256i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < Unroll; i++) {
+        memcpy(tmp + i * NTILE, bzptr, NTILE);
+      }
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = _mm256_loadu_si256((const __m256i*)(tmp + i * 32));
+        bzp[i] = _mm256_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += Unroll) {
+        for (int i = 0; i < NReg; i++) {
+          auto vb = unpack_4bits(b4ptr, vmask);
+          auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+          auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+          vb1 = _mm256_slli_epi32(vb1, 4);
+          vb2 = _mm256_slli_epi32(vb2, 4);
+          vb = _mm256_or_si256(vb, vb1);
+          vb = _mm256_or_si256(vb, vb2);
+          vb = _mm256_sub_epi8(vb, bzp[i]);
+          _mm256_storeu_si256((__m256i*)(tmp + 32 * i), vb);
+          b4ptr += 8 * Unroll / 2;
+          b1ptr += 8 * Unroll / 8;
+          b2ptr += 8 * Unroll / 4;
+        }
+        accumulate_fp32_s8_fp32<MTILE, NReg, Unroll>(A + ib * blocksize + ik, lda, tmp, acc_loc);
+      }
+
+    } else {
+      for (int ik = 0; ik < blocksize; ik += Unroll) {
+        for (int i = 0; i < NReg; i++) {
+          auto vb = unpack_4bits(b4ptr, vmask);
+          auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+          auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+          vb1 = _mm256_slli_epi32(vb1, 4);
+          vb2 = _mm256_slli_epi32(vb2, 4);
+          vb = _mm256_or_si256(vb, vb1);
+          vb = _mm256_or_si256(vb, vb2);
+          vb = _mm256_sub_epi8(vb, vbias);
+          _mm256_storeu_si256((__m256i*)(tmp + 32 * i), vb);
+          b4ptr += 8 * Unroll / 2;
+          b1ptr += 8 * Unroll / 8;
+          b2ptr += 8 * Unroll / 4;
+        }
+        accumulate_fp32_s8_fp32<MTILE, NReg, Unroll>(A + ib * blocksize + ik, lda, tmp, acc_loc);
+      }
+    }
+
+    __m256 v_b_scale[NReg];
+    for (int i = 0; i < NReg; i++) {
+      v_b_scale[i] = load_T_fp32(bsptr + i * 8);
+    }
+    for (int im = 0; im < MTILE; im++) {
+      for (int in = 0; in < NReg; in++) {
+        acc[im * NReg + in] = _mm256_fmadd_ps(acc_loc[im * NReg + in], v_b_scale[in], acc[im * NReg + in]);
+      }
+    }
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm256_storeu_ps(C + i * 8 + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
 static inline __m256i _mm256_dpbusd_avx2_epi32(__m256i& c, const __m256i& a, const __m256i& b) {
   const __m256i dot2 = _mm256_maddubs_epi16(a, b);
   const __m256i ones = _mm256_set1_epi16(1);
@@ -4290,6 +4401,157 @@ static inline BTLA_CODE gemv_6bit_u8s8_fp32(const utils::GemvParamA& A, const ut
               iacc[j * NReg + i] = _mm256_dpbusd_avx2_epi32(iacc[j * NReg + i], va[j], vb);
             }
             b4ptr += 8 * KTILE / 2;
+            b2ptr += 8 * KTILE / 4;
+          }
+        }
+      }
+    }
+
+    gemv_remove_zp<NReg, MReg>(A.zpptr + ib, A.ldzp, iacc, bacc);
+    gemv_dequant_s32fp32<ScaleT, NReg, MTILE>(A.sptr + ib, A.ldzp, B.sptr + ib * B.ldzp, iacc, acc);
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm256_storeu_ps(C + i * 8 + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_7bit_u8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b4ptr = reinterpret_cast<utils::bit4x2*>(B.b4ptr);
+  auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+
+  int blks = k / blocksize;
+  int constexpr NReg = NTILE / 8;
+  int constexpr MReg = MTILE;
+  __m256 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm256_setzero_ps();
+  }
+
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm256_set1_epi8(FullRange);
+
+  const __m256i onesu8 = _mm256_set1_epi8(1);
+  const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+
+  uint32_t mask0 = 0x03030303;
+  auto vmask0 = _mm256_set1_epi32(*(int32_t*)&mask0);
+  auto vshift_y = _mm256_set_epi32(6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm256_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
+  int constexpr KTILE = 4;
+  for (int ib = 0; ib < blks; ib += 1) {
+    __m256i iacc[NReg * MReg];
+    __m256i bacc[NReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      iacc[i] = _mm256_setzero_si256();
+    }
+    for (int i = 0; i < NReg; i++) {
+      bacc[i] = _mm256_setzero_si256();
+    }
+    if (B.zpptr) {
+      __m256i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 8, vindex);
+        bzp[i] = _mm256_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m256i va = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm256_slli_epi32(vb1, 4);
+            vb2 = _mm256_slli_epi32(vb2, 4);
+            vb = _mm256_or_si256(vb, vb1);
+            vb = _mm256_or_si256(vb, vb2);
+            vb = _mm256_sub_epi8(vb, bzp[i]);
+            bacc[i] = _mm256_dpbusd_avx2_epi32(bacc[i], onesu8, vb);
+            iacc[i] = _mm256_dpbusd_avx2_epi32(iacc[i], va, vb);
+            b4ptr += 8 * KTILE / 2;
+            b1ptr += 8 * KTILE / 8;
+            b2ptr += 8 * KTILE / 4;
+          }
+        } else {
+          __m256i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm256_slli_epi32(vb1, 4);
+            vb2 = _mm256_slli_epi32(vb2, 4);
+            vb = _mm256_or_si256(vb, vb1);
+            vb = _mm256_or_si256(vb, vb2);
+            vb = _mm256_sub_epi8(vb, bzp[i]);
+            bacc[i] = _mm256_dpbusd_avx2_epi32(bacc[i], onesu8, vb);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm256_dpbusd_avx2_epi32(iacc[j * NReg + i], va[j], vb);
+            }
+            b4ptr += 8 * KTILE / 2;
+            b1ptr += 8 * KTILE / 8;
+            b2ptr += 8 * KTILE / 4;
+          }
+        }
+      }
+    } else {
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m256i va = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm256_slli_epi32(vb1, 4);
+            vb2 = _mm256_slli_epi32(vb2, 4);
+            vb = _mm256_or_si256(vb, vb1);
+            vb = _mm256_or_si256(vb, vb2);
+            vb = _mm256_sub_epi8(vb, vbias);
+            bacc[i] = _mm256_dpbusd_avx2_epi32(bacc[i], onesu8, vb);
+            iacc[i] = _mm256_dpbusd_avx2_epi32(iacc[i], va, vb);
+            b4ptr += 8 * KTILE / 2;
+            b1ptr += 8 * KTILE / 8;
+            b2ptr += 8 * KTILE / 4;
+          }
+        } else {
+          __m256i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm256_slli_epi32(vb1, 4);
+            vb2 = _mm256_slli_epi32(vb2, 4);
+            vb = _mm256_or_si256(vb, vb1);
+            vb = _mm256_or_si256(vb, vb2);
+            vb = _mm256_sub_epi8(vb, vbias);
+            bacc[i] = _mm256_dpbusd_avx2_epi32(bacc[i], onesu8, vb);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm256_dpbusd_avx2_epi32(iacc[j * NReg + i], va[j], vb);
+            }
+            b4ptr += 8 * KTILE / 2;
+            b1ptr += 8 * KTILE / 8;
             b2ptr += 8 * KTILE / 4;
           }
         }
@@ -5677,6 +5939,266 @@ static inline BTLA_CODE gemv_6bit_s8s8_fp32(const utils::GemvParamA& A, const ut
           }
           b4ptr += 8 * KTILE / 2;
           b2ptr += 8 * KTILE / 4;
+        }
+      }
+    }
+
+    gemv_dequant_s32fp32<ScaleT, NReg, MTILE>(A.sptr + ib, A.ldzp, B.sptr + ib * B.ldzp, iacc, acc);
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm256_storeu_ps(C + i * 8 + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_7bit_u8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b4ptr = reinterpret_cast<utils::bit4x2*>(B.b4ptr);
+  auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+
+  int blks = k / blocksize;
+  int constexpr NReg = NTILE / 8;
+  int constexpr MReg = MTILE;
+  __m256 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm256_setzero_ps();
+  }
+
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm256_set1_epi8(FullRange);
+
+  const __m256i onesu8 = _mm256_set1_epi8(1);
+  const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+
+  uint32_t mask0 = 0x03030303;
+  auto vmask0 = _mm256_set1_epi32(*(int32_t*)&mask0);
+  auto vshift_y = _mm256_set_epi32(6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm256_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
+  int constexpr KTILE = 4;
+  for (int ib = 0; ib < blks; ib += 1) {
+    __m256i iacc[NReg * MReg];
+    __m256i bacc[NReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      iacc[i] = _mm256_setzero_si256();
+    }
+    for (int i = 0; i < NReg; i++) {
+      bacc[i] = _mm256_setzero_si256();
+    }
+    if (B.zpptr) {
+      __m256i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 8, vindex);
+        bzp[i] = _mm256_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m256i va = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm256_slli_epi32(vb1, 4);
+            vb2 = _mm256_slli_epi32(vb2, 4);
+            vb = _mm256_or_si256(vb, vb1);
+            vb = _mm256_or_si256(vb, vb2);
+            vb = _mm256_sub_epi8(vb, bzp[i]);
+            bacc[i] = _mm256_dpbusd_avx_epi32(bacc[i], onesu8, vb);
+            iacc[i] = _mm256_dpbusd_avx_epi32(iacc[i], va, vb);
+            b4ptr += 8 * KTILE / 2;
+            b1ptr += 8 * KTILE / 8;
+            b2ptr += 8 * KTILE / 4;
+          }
+        } else {
+          __m256i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm256_slli_epi32(vb1, 4);
+            vb2 = _mm256_slli_epi32(vb2, 4);
+            vb = _mm256_or_si256(vb, vb1);
+            vb = _mm256_or_si256(vb, vb2);
+            vb = _mm256_sub_epi8(vb, bzp[i]);
+            bacc[i] = _mm256_dpbusd_avx_epi32(bacc[i], onesu8, vb);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm256_dpbusd_avx_epi32(iacc[j * NReg + i], va[j], vb);
+            }
+            b4ptr += 8 * KTILE / 2;
+            b1ptr += 8 * KTILE / 8;
+            b2ptr += 8 * KTILE / 4;
+          }
+        }
+      }
+    } else {
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m256i va = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm256_slli_epi32(vb1, 4);
+            vb2 = _mm256_slli_epi32(vb2, 4);
+            vb = _mm256_or_si256(vb, vb1);
+            vb = _mm256_or_si256(vb, vb2);
+            vb = _mm256_sub_epi8(vb, vbias);
+            bacc[i] = _mm256_dpbusd_avx_epi32(bacc[i], onesu8, vb);
+            iacc[i] = _mm256_dpbusd_avx_epi32(iacc[i], va, vb);
+            b4ptr += 8 * KTILE / 2;
+            b1ptr += 8 * KTILE / 8;
+            b2ptr += 8 * KTILE / 4;
+          }
+        } else {
+          __m256i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm256_slli_epi32(vb1, 4);
+            vb2 = _mm256_slli_epi32(vb2, 4);
+            vb = _mm256_or_si256(vb, vb1);
+            vb = _mm256_or_si256(vb, vb2);
+            vb = _mm256_sub_epi8(vb, vbias);
+            bacc[i] = _mm256_dpbusd_avx_epi32(bacc[i], onesu8, vb);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm256_dpbusd_avx_epi32(iacc[j * NReg + i], va[j], vb);
+            }
+            b4ptr += 8 * KTILE / 2;
+            b1ptr += 8 * KTILE / 8;
+            b2ptr += 8 * KTILE / 4;
+          }
+        }
+      }
+    }
+
+    gemv_remove_zp<NReg, MReg>(A.zpptr + ib, A.ldzp, iacc, bacc);
+    gemv_dequant_s32fp32<ScaleT, NReg, MTILE>(A.sptr + ib, A.ldzp, B.sptr + ib * B.ldzp, iacc, acc);
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm256_storeu_ps(C + i * 8 + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_7bit_s8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b4ptr = reinterpret_cast<utils::bit4x2*>(B.b4ptr);
+  auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+
+  int blks = k / blocksize;
+  int constexpr NReg = NTILE / 8;
+  int constexpr MReg = MTILE;
+  __m256 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm256_setzero_ps();
+  }
+  int constexpr FullRange = 1 << (6 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm256_set1_epi8(FullRange);
+  const __m256i onesu8 = _mm256_set1_epi8(1);
+  const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0);
+
+  uint32_t mask0 = 0x03030303;
+  auto vmask0 = _mm256_set1_epi32(*(int32_t*)&mask0);
+  auto vshift_y = _mm256_set_epi32(6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm256_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+
+  int constexpr KTILE = 4;
+  for (int ib = 0; ib < blks; ib += 1) {
+    __m256i iacc[NReg * MReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      iacc[i] = _mm256_setzero_si256();
+    }
+    if (B.zpptr) {
+      __m256i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 8, vindex);
+        bzp[i] = _mm256_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        __m256i va[MReg];
+        for (int i = 0; i < MReg; i++) {
+          va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+        }
+        for (int i = 0; i < NReg; i++) {
+          auto vb = unpack_4bits(b4ptr, vmask);
+          auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+          auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+          vb1 = _mm256_slli_epi32(vb1, 4);
+          vb2 = _mm256_slli_epi32(vb2, 4);
+          vb = _mm256_or_si256(vb, vb1);
+          vb = _mm256_or_si256(vb, vb2);
+          vb = _mm256_sub_epi8(vb, bzp[i]);
+          for (int j = 0; j < MReg; j++) {
+            auto vsb = _mm256_sign_epi8(vb, va[j]);
+            auto vabsa = _mm256_sign_epi8(va[j], va[j]);
+            iacc[j * NReg + i] = _mm256_dpbusd_avx_epi32(iacc[j * NReg + i], vabsa, vsb);
+          }
+          b4ptr += 8 * KTILE / 2;
+          b2ptr += 8 * KTILE / 4;
+          b1ptr += 8 * KTILE / 8;
+        }
+      }
+    } else {
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        __m256i va[MReg];
+        for (int i = 0; i < MReg; i++) {
+          va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+        }
+        for (int i = 0; i < NReg; i++) {
+          auto vb = unpack_4bits(b4ptr, vmask);
+          auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+          auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+          vb1 = _mm256_slli_epi32(vb1, 4);
+          vb2 = _mm256_slli_epi32(vb2, 4);
+          vb = _mm256_or_si256(vb, vb1);
+          vb = _mm256_or_si256(vb, vb2);
+          vb = _mm256_sub_epi8(vb, vbias);
+          for (int j = 0; j < MReg; j++) {
+            auto vsb = _mm256_sign_epi8(vb, va[j]);
+            auto vabsa = _mm256_sign_epi8(va[j], va[j]);
+            iacc[j * NReg + i] = _mm256_dpbusd_avx_epi32(iacc[j * NReg + i], vabsa, vsb);
+          }
+          b4ptr += 8 * KTILE / 2;
+          b2ptr += 8 * KTILE / 4;
+          b1ptr += 8 * KTILE / 8;
         }
       }
     }

--- a/bestla/bestla/kernel_avx2.h
+++ b/bestla/bestla/kernel_avx2.h
@@ -550,7 +550,7 @@ static inline BTLA_CODE decompress_kblock_s4_s8(utils::int4x2* srcptr, int8_t* z
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::int4x2 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -764,7 +764,7 @@ static inline BTLA_CODE decompress_kblock_s2_s8(utils::bit2x4* bit2ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -1022,7 +1022,7 @@ static inline BTLA_CODE decompress_kblock_s3_s8(utils::bit2x4* bit2ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -1276,7 +1276,7 @@ static inline BTLA_CODE decompress_kblock_s5_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -1310,6 +1310,321 @@ static inline BTLA_CODE decompress_kblock_s5_s8(utils::bit4x2* bit4ptr, utils::b
   } else {
     size_t elesize = static_cast<size_t>(row) * col;
     return decompress_s5_s8(bit4ptr, bit1ptr, dstptr, elesize, tmp, tmpsize);
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int NTILE>
+static inline BTLA_CODE decompress_kblock_s7_s8_pack4_row(utils::bit4x2* srcptr, utils::bit2x4* bit2ptr,
+                                                          utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+                                                          int blocksize, int ldzp, int n_offset, int k_offset, int row,
+                                                          int8_t* tmp, size_t tmpsize) {
+  int constexpr NReg = NTILE / 8;
+  static_assert((NTILE % 8) == 0);
+  int constexpr PackRow = 4;
+  __m256i v_zp_y[NReg];
+  const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0);
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm256_set1_epi8(FullRange);
+
+  uint32_t mask0 = 0x03030303;
+  auto vmask0 = _mm256_set1_epi32(*(int32_t*)&mask0);
+  auto vshift_y = _mm256_set_epi32(6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm256_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+  for (int ir = 0; ir < row; ir += blocksize) {
+    auto zptr = zpptr + (k_offset + ir) / blocksize * ldzp + n_offset;
+    for (int i = 0; i < NReg; i++) {
+      v_zp_y[i] = load_zp_epi8_broadcast_epi32(zptr + i * 8, vindex);
+      v_zp_y[i] = _mm256_add_epi8(v_zp_y[i], vbias);
+    }
+    int k_remain = utils::remainsize(ir, row, blocksize);
+    for (int ib = 0; ib < k_remain; ib += PackRow) {
+      auto b4ptr = srcptr + (ir + ib) * NTILE / 2;
+      auto b1ptr = bit1ptr + (ir + ib) * NTILE / 8;
+      auto b2ptr = bit2ptr + (ir + ib) * NTILE / 4;
+      for (int i = 0; i < NReg; i++) {
+        auto v_s8_y = unpack_4bits(b4ptr + i * 16, vmask);
+        auto vb1 = unpack_1bits(b1ptr + i * 4, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+        auto vb2 = unpack_2bits(b2ptr + i * 8, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+        vb1 = _mm256_slli_epi32(vb1, 4);
+        vb2 = _mm256_slli_epi32(vb2, 4);
+        v_s8_y = _mm256_or_si256(v_s8_y, vb1);
+        v_s8_y = _mm256_or_si256(v_s8_y, vb2);
+        v_s8_y = _mm256_sub_epi8(v_s8_y, v_zp_y[i]);
+        _mm256_storeu_si256((__m256i*)(dstptr + i * 32 + (ir + ib) * NTILE), v_s8_y);
+      }
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int NTILE>
+static inline BTLA_CODE decompress_kblock_s7_s8_pack2_row(utils::bit4x2* srcptr, utils::bit2x4* bit2ptr,
+                                                          utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+                                                          int blocksize, int ldzp, int n_offset, int k_offset, int row,
+                                                          int8_t* tmp, size_t tmpsize) {
+  int constexpr NReg = NTILE / 8;
+  static_assert((NTILE % 8) == 0);
+  int constexpr PackRow = 2;
+  int constexpr Unroll = 2;
+  __m256i v_zp_y[NReg];
+  const auto vindex = _mm256_set_epi8(14, 14, 12, 12, 10, 10, 8, 8, 6, 6, 4, 4, 2, 2, 0, 0, 14, 14, 12, 12, 10, 10, 8,
+                                      8, 6, 6, 4, 4, 2, 2, 0, 0);
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm256_set1_epi8(FullRange);
+
+  uint32_t mask0 = 0x03030303;
+  auto vmask0 = _mm256_set1_epi32(*(int32_t*)&mask0);
+  auto vshift_y = _mm256_set_epi32(6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm256_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+
+  for (int ir = 0; ir < row; ir += blocksize) {
+    auto zptr = zpptr + (k_offset + ir) / blocksize * ldzp + n_offset;
+    memcpy(tmp, zptr, NTILE * sizeof(int8_t));
+    memcpy(tmp + NTILE, zptr, NTILE * sizeof(int8_t));
+    for (int i = 0; i < NReg; i++) {
+      v_zp_y[i] = load_zp_epi8_broadcast_epi16_v16(tmp + i * 16, vindex);
+      v_zp_y[i] = _mm256_add_epi8(v_zp_y[i], vbias);
+    }
+    int k_remain = utils::remainsize(ir, row, blocksize);
+    int k_remain_unrll = utils::padto_le(k_remain, PackRow * Unroll);
+    int ib = 0;
+    for (; ib < k_remain_unrll; ib += PackRow * Unroll) {
+      auto b4ptr = srcptr + (ir + ib) * NTILE / 2;
+      auto b1ptr = bit1ptr + (ir + ib) * NTILE / 8;
+      auto b2ptr = bit2ptr + (ir + ib) * NTILE / 4;
+      for (int i = 0; i < NReg; i++) {
+        auto v_s8_y = unpack_4bits(b4ptr + i * 16, vmask);
+        auto vb1 = unpack_1bits(b1ptr + i * 4, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+        auto vb2 = unpack_2bits(b2ptr + i * 8, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+        vb1 = _mm256_slli_epi32(vb1, 4);
+        vb2 = _mm256_slli_epi32(vb2, 4);
+        v_s8_y = _mm256_or_si256(v_s8_y, vb1);
+        v_s8_y = _mm256_or_si256(v_s8_y, vb2);
+        v_s8_y = _mm256_sub_epi8(v_s8_y, v_zp_y[i]);
+        _mm256_storeu_si256((__m256i*)(dstptr + i * 32 + (ir + ib) * NTILE), v_s8_y);
+      }
+    }
+    int k_tail = k_remain - k_remain_unrll;
+    if (k_tail > 0) {
+      auto tmpb4ptr = tmp;
+      memcpy(tmpb4ptr, srcptr + (ir + ib) * NTILE / 2, k_tail * NTILE / 2);
+      auto tmpb1ptr = tmp + Unroll * NTILE / 2;
+      memcpy(tmpb1ptr, bit1ptr + (ir + ib) * NTILE / 8, k_tail * NTILE / 8);
+      auto tmpb2ptr = tmp + Unroll * NTILE * 3 / 4;
+      memcpy(tmpb2ptr, bit2ptr + (ir + ib) * NTILE / 4, k_tail * NTILE / 4);
+      auto tmpout = tmp + Unroll * NTILE;
+      for (int i = 0; i < NReg; i++) {
+        auto v_s8_y = unpack_4bits((utils::bit4x2*)(tmpb4ptr + i * 16), vmask);
+        auto vb1 = unpack_1bits((utils::bit1x8*)(tmpb1ptr + i * 4), bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+        auto vb2 = unpack_2bits((utils::bit2x4*)(tmpb2ptr + i * 8), vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+        vb1 = _mm256_slli_epi32(vb1, 4);
+        vb2 = _mm256_slli_epi32(vb2, 4);
+        v_s8_y = _mm256_or_si256(v_s8_y, vb1);
+        v_s8_y = _mm256_or_si256(v_s8_y, vb2);
+        v_s8_y = _mm256_sub_epi8(v_s8_y, v_zp_y[i]);
+        _mm256_storeu_si256((__m256i*)(tmpout + i * 32), v_s8_y);
+      }
+      memcpy(dstptr + (ir + ib) * NTILE, tmpout, k_tail * NTILE);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int NTILE>
+static inline BTLA_CODE decompress_kblock_s7_s8_pack1_row(utils::bit4x2* srcptr, utils::bit2x4* bit2ptr,
+                                                          utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+                                                          int blocksize, int ldzp, int n_offset, int k_offset, int row,
+                                                          int8_t* tmp, size_t tmpsize) {
+  int constexpr NReg = NTILE / 8;
+  static_assert((NTILE % 8) == 0);
+  int constexpr PackRow = 1;
+  int constexpr Unroll = 4;
+  int constexpr UnpackLoop = Unroll * NTILE / 32;
+  int constexpr FullRange = 1 << (7 - 1);
+  __m256i v_zp_y[UnpackLoop];
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm256_set1_epi8(FullRange);
+
+  uint32_t mask0 = 0x03030303;
+  auto vmask0 = _mm256_set1_epi32(*(int32_t*)&mask0);
+  auto vshift_y = _mm256_set_epi32(6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm256_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+  for (int ir = 0; ir < row; ir += blocksize) {
+    auto zptr = zpptr + (k_offset + ir) / blocksize * ldzp + n_offset;
+    for (int i = 0; i < Unroll; i++) {
+      memcpy(tmp + i * NTILE, zptr, NTILE * sizeof(int8_t));
+    }
+    for (int i = 0; i < UnpackLoop; i++) {
+      v_zp_y[i] = _mm256_loadu_si256((const __m256i*)(tmp + i * 32));
+      v_zp_y[i] = _mm256_add_epi8(v_zp_y[i], vbias);
+    }
+    int k_remain = utils::remainsize(ir, row, blocksize);
+    int k_remain_unrll = utils::padto_le(k_remain, Unroll);
+    int ib = 0;
+    for (; ib < k_remain_unrll; ib += Unroll) {
+      auto b4ptr = srcptr + (ir + ib) * NTILE / 2;
+      auto b1ptr = bit1ptr + (ir + ib) * NTILE / 8;
+      auto b2ptr = bit2ptr + (ir + ib) * NTILE / 4;
+      for (int i = 0; i < UnpackLoop; i++) {
+        auto v_s8_y = unpack_4bits(b4ptr + i * 16, vmask);
+        auto vb1 = unpack_1bits(b1ptr + i * 4, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+        auto vb2 = unpack_2bits(b2ptr + i * 8, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+        vb1 = _mm256_slli_epi32(vb1, 4);
+        vb2 = _mm256_slli_epi32(vb2, 4);
+        v_s8_y = _mm256_or_si256(v_s8_y, vb1);
+        v_s8_y = _mm256_or_si256(v_s8_y, vb2);
+        v_s8_y = _mm256_sub_epi8(v_s8_y, v_zp_y[i]);
+        _mm256_storeu_si256((__m256i*)(dstptr + i * 32 + (ir + ib) * NTILE), v_s8_y);
+      }
+    }
+
+    int k_tail = k_remain - k_remain_unrll;
+    if (k_tail > 0) {
+      auto tmpb4ptr = tmp;
+      memcpy(tmpb4ptr, srcptr + (ir + ib) * NTILE / 2, k_tail * NTILE / 2);
+      auto tmpb1ptr = tmp + Unroll * NTILE / 2;
+      memcpy(tmpb1ptr, bit1ptr + (ir + ib) * NTILE / 8, k_tail * NTILE / 8);
+      auto tmpb2ptr = tmp + Unroll * NTILE * 3 / 4;
+      memcpy(tmpb2ptr, bit2ptr + (ir + ib) * NTILE / 4, k_tail * NTILE / 4);
+      auto tmpout = tmp + Unroll * NTILE;
+      for (int i = 0; i < UnpackLoop; i++) {
+        auto v_s8_y = unpack_4bits((utils::bit4x2*)(tmpb4ptr + i * 16), vmask);
+        auto vb1 = unpack_1bits((utils::bit1x8*)(tmpb1ptr + i * 4), bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+        auto vb2 = unpack_2bits((utils::bit2x4*)(tmpb2ptr + i * 8), vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+        vb1 = _mm256_slli_epi32(vb1, 4);
+        vb2 = _mm256_slli_epi32(vb2, 4);
+        v_s8_y = _mm256_or_si256(v_s8_y, vb1);
+        v_s8_y = _mm256_or_si256(v_s8_y, vb2);
+        v_s8_y = _mm256_sub_epi8(v_s8_y, v_zp_y[i]);
+        _mm256_storeu_si256((__m256i*)(tmpout + i * 32), v_s8_y);
+      }
+      memcpy(dstptr + (ir + ib) * NTILE, tmpout, k_tail * NTILE);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+static inline BTLA_CODE decompress_s7_s8(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
+                                         int8_t* dstptr, size_t unpack_elt, int8_t* tmp, size_t tmpsize) {
+  int constexpr VBits = 256;
+  int constexpr VElt = VBits / 8;
+  int i = 0;
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm256_set1_epi8(FullRange);
+
+  uint32_t mask0 = 0x03030303;
+  auto vmask0 = _mm256_set1_epi32(*(int32_t*)&mask0);
+  auto vshift_y = _mm256_set_epi32(6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm256_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+  int elt_pad = utils::padto_le(unpack_elt, VElt);
+  for (; i < elt_pad; i += VElt) {
+    auto vout = unpack_4bits(bit4ptr + i / 2, vmask);
+    auto vb1 = unpack_1bits(bit1ptr + i / 8, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+    auto vb2 = unpack_2bits(bit2ptr + i / 4, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+    vb1 = _mm256_slli_epi32(vb1, 4);
+    vb2 = _mm256_slli_epi32(vb2, 4);
+    vout = _mm256_or_si256(vout, vb1);
+    vout = _mm256_or_si256(vout, vb2);
+    vout = _mm256_sub_epi8(vout, vbias);
+    _mm256_storeu_si256((__m256i*)(dstptr + i), vout);
+  }
+  if (elt_pad < unpack_elt) {
+    if (unpack_elt >= 32) {
+      i = unpack_elt - 32;
+      auto vout = unpack_4bits(bit4ptr + i / 2, vmask);
+      auto vb1 = unpack_1bits(bit1ptr + i / 8, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+      auto vb2 = unpack_2bits(bit2ptr + i / 4, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+      vb1 = _mm256_slli_epi32(vb1, 4);
+      vb2 = _mm256_slli_epi32(vb2, 4);
+      vout = _mm256_or_si256(vout, vb1);
+      vout = _mm256_or_si256(vout, vb2);
+      vout = _mm256_sub_epi8(vout, vbias);
+      _mm256_storeu_si256((__m256i*)(dstptr + i), vout);
+    } else {
+      ref::decompress_s7_s8(bit4ptr + i / 2, bit2ptr + i / 4, bit1ptr + i / 8, dstptr + i, unpack_elt - i, tmp,
+                            tmpsize);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int PackRow, int NTILE>
+static inline BTLA_CODE decompress_kblock_s7_s8(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
+                                                int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset,
+                                                int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
+  if (zpptr) {
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
+                                    int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
+                                    int row, int8_t* tmp, size_t tmpsize);
+    decompfunc func = nullptr;
+    if (col == NTILE) {
+      if constexpr (PackRow == 1) {
+        func = &decompress_kblock_s7_s8_pack1_row<NTILE>;
+      }
+      if constexpr (PackRow == 2) {
+        func = &decompress_kblock_s7_s8_pack2_row<NTILE>;
+      }
+      if constexpr (PackRow == 4) {
+        func = &decompress_kblock_s7_s8_pack4_row<NTILE>;
+      }
+      if (func) {
+        int head_end = utils::padto(k_offset, blocksize);
+        head_end = std::min(head_end, k_offset + row);
+        int head_size = head_end - k_offset;
+        if (head_size > 0) {
+          (*func)(bit4ptr, bit2ptr, bit1ptr, zpptr, dstptr, blocksize, ldzp, n_offset, k_offset, head_size, tmp,
+                  tmpsize);
+        }
+        int body_size = row - head_size;
+        if (body_size > 0) {
+          (*func)(bit4ptr + head_size * NTILE / 2, bit2ptr + head_size * NTILE / 4, bit1ptr + head_size * NTILE / 8,
+                  zpptr, dstptr + head_size * NTILE, blocksize, ldzp, n_offset, head_end, body_size, tmp, tmpsize);
+        }
+        return BTLA_CODE::Success;
+      }
+    }
+    assert(0);
+    return BTLA_CODE::NotSupport;
+  } else {
+    size_t elesize = static_cast<size_t>(row) * col;
+    return decompress_s7_s8(bit4ptr, bit2ptr, bit1ptr, dstptr, elesize, tmp, tmpsize);
   }
   return BTLA_CODE::Success;
 }
@@ -1538,7 +1853,7 @@ static inline BTLA_CODE decompress_kblock_s6_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -2224,6 +2539,50 @@ inline BTLA_CODE decompress_kblock_s6_fp(utils::bit4x2* b4ptr, utils::bit2x4* b2
       decompress_kblock_s6_fp_row<PackRow, NTILE, DST_T>(
           b4ptr + head_size * NTILE / 2, b2ptr + head_size * NTILE / 4, dstptr + head_size * NTILE, body_size, scales_,
           sdtype, zero_points, head_end, n_offset, blocksize, ldzp, tmp, tmpsize);
+    }
+    return BTLA_CODE::Success;
+  }
+  return ret;
+}
+
+template <int PackRow, int NTILE, typename DST_T>
+inline BTLA_CODE decompress_kblock_s7_fp_row(utils::bit4x2* b4ptr, utils::bit2x4* b2ptr, utils::bit1x8* b1ptr,
+                                             DST_T* dstptr, int row, void* scales_, BTLA_DTYPE sdtype,
+                                             int8_t* zero_points, int k_offset, int n_offset, int blocksize, int ldzp,
+                                             int8_t* tmp, size_t tmpsize) {
+  int constexpr NReg = NTILE / 8;
+  const auto DstSize = row * NTILE * sizeof(DST_T);
+  const auto S8Size = row * NTILE * sizeof(int8_t);
+  auto tmps8ptr = (int8_t*)dstptr;
+  tmps8ptr += DstSize - S8Size;
+  auto ret = decompress_kblock_s7_s8<PackRow, NTILE>(b4ptr, b2ptr, b1ptr, zero_points, tmps8ptr, blocksize, ldzp,
+                                                     n_offset, k_offset, row, NTILE, tmp, tmpsize);
+  assert(ret == BTLA_CODE::Success);
+  return decompress_kblock_s8_fp_row<PackRow, NTILE, DST_T>(tmps8ptr, dstptr, row, scales_, sdtype, nullptr, k_offset,
+                                                            n_offset, blocksize, ldzp, tmp, tmpsize);
+}
+
+template <int PackRow, int NTILE, typename DST_T>
+inline BTLA_CODE decompress_kblock_s7_fp(utils::bit4x2* b4ptr, utils::bit2x4* b2ptr, utils::bit1x8* b1ptr,
+                                         DST_T* dstptr, int row, int col, void* scales_, BTLA_DTYPE sdtype,
+                                         int8_t* zero_points, int k_offset, int n_offset, int blocksize, int ldzp,
+                                         int8_t* tmp, size_t tmpsize) {
+  auto ret = BTLA_CODE::NotSupport;
+  if (col == NTILE) {
+    int head_end = utils::padto(k_offset, blocksize);
+    head_end = std::min(head_end, k_offset + row);
+    int head_size = head_end - k_offset;
+    if (head_size > 0) {
+      decompress_kblock_s7_fp_row<PackRow, NTILE, DST_T>(b4ptr, b2ptr, b1ptr, dstptr, head_size, scales_, sdtype,
+                                                         zero_points, k_offset, n_offset, blocksize, ldzp, tmp,
+                                                         tmpsize);
+    }
+    int body_size = row - head_size;
+    if (body_size > 0) {
+      decompress_kblock_s7_fp_row<PackRow, NTILE, DST_T>(b4ptr + head_size * NTILE / 2, b2ptr + head_size * NTILE / 4,
+                                                         b1ptr + head_size * NTILE / 8, dstptr + head_size * NTILE,
+                                                         body_size, scales_, sdtype, zero_points, head_end, n_offset,
+                                                         blocksize, ldzp, tmp, tmpsize);
     }
     return BTLA_CODE::Success;
   }

--- a/bestla/bestla/kernel_avx512f.h
+++ b/bestla/bestla/kernel_avx512f.h
@@ -2594,7 +2594,7 @@ template <int PackRow, int NTILE>
 inline BTLA_CODE decompress_kblock_s4_s8(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                          int n_offset, int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::int4x2 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -2816,7 +2816,7 @@ static inline BTLA_CODE decompress_kblock_s2_s8(utils::bit2x4* bit2ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -3074,7 +3074,7 @@ static inline BTLA_CODE decompress_kblock_s3_s8(utils::bit2x4* bit2ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -3325,7 +3325,7 @@ static inline BTLA_CODE decompress_kblock_s5_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -3639,9 +3639,9 @@ static inline BTLA_CODE decompress_kblock_s7_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset,
                                                 int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
-                                    int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
-                                    int row, int8_t* tmp, size_t tmpsize);
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr,
+                                    int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp, int n_offset,
+                                    int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
       if constexpr (PackRow == 1) {
@@ -3910,7 +3910,7 @@ static inline BTLA_CODE decompress_kblock_s6_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -6130,7 +6130,7 @@ static inline BTLA_CODE gemv_7bit_u8s8_fp32(const utils::GemvParamA& A, const ut
                                       4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12,
                                       12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0);
 
-    uint64_t mask0 = 0x0303030303030303;
+  uint64_t mask0 = 0x0303030303030303;
   auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
   auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
   auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,

--- a/bestla/bestla/kernel_avx512f.h
+++ b/bestla/bestla/kernel_avx512f.h
@@ -4355,6 +4355,50 @@ inline BTLA_CODE decompress_kblock_s6_fp(utils::bit4x2* b4ptr, utils::bit2x4* b2
   return ret;
 }
 
+template <int PackRow, int NTILE, typename DST_T>
+inline BTLA_CODE decompress_kblock_s7_fp_row(utils::bit4x2* b4ptr, utils::bit2x4* b2ptr, utils::bit1x8* b1ptr,
+                                             DST_T* dstptr, int row, void* scales_, BTLA_DTYPE sdtype,
+                                             int8_t* zero_points, int k_offset, int n_offset, int blocksize, int ldzp,
+                                             int8_t* tmp, size_t tmpsize) {
+  int constexpr NReg = NTILE / 8;
+  const auto DstSize = row * NTILE * sizeof(DST_T);
+  const auto S8Size = row * NTILE * sizeof(int8_t);
+  auto tmps8ptr = (int8_t*)dstptr;
+  tmps8ptr += DstSize - S8Size;
+  auto ret = decompress_kblock_s7_s8<PackRow, NTILE>(b4ptr, b2ptr, b1ptr, zero_points, tmps8ptr, blocksize, ldzp,
+                                                     n_offset, k_offset, row, NTILE, tmp, tmpsize);
+  assert(ret == BTLA_CODE::Success);
+  return decompress_kblock_s8_fp_row<PackRow, NTILE, DST_T>(tmps8ptr, dstptr, row, scales_, sdtype, nullptr, k_offset,
+                                                            n_offset, blocksize, ldzp, tmp, tmpsize);
+}
+
+template <int PackRow, int NTILE, typename DST_T>
+inline BTLA_CODE decompress_kblock_s7_fp(utils::bit4x2* b4ptr, utils::bit2x4* b2ptr, utils::bit1x8* b1ptr,
+                                         DST_T* dstptr, int row, int col, void* scales_, BTLA_DTYPE sdtype,
+                                         int8_t* zero_points, int k_offset, int n_offset, int blocksize, int ldzp,
+                                         int8_t* tmp, size_t tmpsize) {
+  auto ret = BTLA_CODE::NotSupport;
+  if (col == NTILE) {
+    int head_end = utils::padto(k_offset, blocksize);
+    head_end = std::min(head_end, k_offset + row);
+    int head_size = head_end - k_offset;
+    if (head_size > 0) {
+      decompress_kblock_s7_fp_row<PackRow, NTILE, DST_T>(b4ptr, b2ptr, b1ptr, dstptr, head_size, scales_, sdtype,
+                                                         zero_points, k_offset, n_offset, blocksize, ldzp, tmp,
+                                                         tmpsize);
+    }
+    int body_size = row - head_size;
+    if (body_size > 0) {
+      decompress_kblock_s7_fp_row<PackRow, NTILE, DST_T>(b4ptr + head_size * NTILE / 2, b2ptr + head_size * NTILE / 4,
+                                                         b1ptr + head_size * NTILE / 8, dstptr + head_size * NTILE,
+                                                         body_size, scales_, sdtype, zero_points, head_end, n_offset,
+                                                         blocksize, ldzp, tmp, tmpsize);
+    }
+    return BTLA_CODE::Success;
+  }
+  return ret;
+}
+
 template <typename T>
 static inline __m512 load_T_fp32(const T* srcptr) {
   __m512 vtmp;
@@ -4885,6 +4929,116 @@ static inline BTLA_CODE gemv_6bit_fp32_fp32(const float* A, int lda, const utils
           _mm512_storeu_si512((__m512i*)(tmp + 64 * i), vb);
           b4ptr += VLen * Unroll / 2;
           b2ptr += VLen * Unroll / 4;
+        }
+        accumulate_fp32_s8_fp32<MTILE, NReg, Unroll>(A + ib * blocksize + ik, lda, tmp, acc_loc);
+      }
+    }
+
+    __m512 v_b_scale[NReg];
+    for (int i = 0; i < NReg; i++) {
+      v_b_scale[i] = load_T_fp32(bsptr + i * VLen);
+    }
+    for (int im = 0; im < MTILE; im++) {
+      for (int in = 0; in < NReg; in++) {
+        acc[im * NReg + in] = _mm512_fmadd_ps(acc_loc[im * NReg + in], v_b_scale[in], acc[im * NReg + in]);
+      }
+    }
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm512_storeu_ps(C + i * VLen + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_7bit_fp32_fp32(const float* A, int lda, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b4ptr = (utils::bit4x2*)B.b4ptr;
+  auto b2ptr = (utils::bit2x4*)B.b2ptr;
+  auto b1ptr = (utils::bit1x8*)B.b1ptr;
+
+  int constexpr VLen = 16;
+  int blks = k / blocksize;
+  int constexpr NReg = NTILE / VLen;
+  int constexpr MReg = MTILE;
+  __m512 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm512_setzero_ps();
+  }
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm512_set1_epi8(FullRange);
+
+  auto zmm_0x04 = _mm512_set1_epi8(0x04);
+  auto zmm_0x00 = _mm512_set1_epi8(0x00);
+
+  uint64_t mask0 = 0x0303030303030303;
+  auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
+  auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
+                                      15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm512_set_epi32(3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0);
+
+  int constexpr KTILE = 1;
+  for (int ib = 0; ib < blks; ib += 1) {
+    auto bsptr = B.sptr + ib * B.ldzp;
+
+    __m512 acc_loc[NReg * MReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      acc_loc[i] = _mm512_setzero_ps();
+    }
+    int constexpr Unroll = 4;
+    assert((blocksize % 4) == 0);
+    assert(tmpsize >= NTILE * Unroll);
+
+    if (B.zpptr) {
+      __m512i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < Unroll; i++) {
+        memcpy(tmp + i * NTILE, bzptr, NTILE);
+      }
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = _mm512_loadu_si512((const __m512i*)(tmp + i * 64));
+        bzp[i] = _mm512_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += Unroll) {
+        for (int i = 0; i < NReg; i++) {
+          auto vb = unpack_4bits(b4ptr, vmask);
+          auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+          auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+          vb1 = _mm512_slli_epi32(vb1, 4);
+          vb2 = _mm512_slli_epi32(vb2, 4);
+          vb = _mm512_or_si512(vb, vb1);
+          vb = _mm512_or_si512(vb, vb2);
+          vb = _mm512_sub_epi8(vb, bzp[i]);
+          _mm512_storeu_si512((__m512i*)(tmp + 64 * i), vb);
+          b4ptr += VLen * Unroll / 2;
+          b2ptr += VLen * Unroll / 4;
+          b1ptr += VLen * Unroll / 8;
+        }
+        accumulate_fp32_s8_fp32<MTILE, NReg, Unroll>(A + ib * blocksize + ik, lda, tmp, acc_loc);
+      }
+
+    } else {
+      for (int ik = 0; ik < blocksize; ik += Unroll) {
+        for (int i = 0; i < NReg; i++) {
+          auto vb = unpack_4bits(b4ptr, vmask);
+          auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+          auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+          vb1 = _mm512_slli_epi32(vb1, 4);
+          vb2 = _mm512_slli_epi32(vb2, 4);
+          vb = _mm512_or_si512(vb, vb1);
+          vb = _mm512_or_si512(vb, vb2);
+          vb = _mm512_sub_epi8(vb, vbias);
+          _mm512_storeu_si512((__m512i*)(tmp + 64 * i), vb);
+          b4ptr += VLen * Unroll / 2;
+          b2ptr += VLen * Unroll / 4;
+          b1ptr += VLen * Unroll / 8;
         }
         accumulate_fp32_s8_fp32<MTILE, NReg, Unroll>(A + ib * blocksize + ik, lda, tmp, acc_loc);
       }
@@ -5935,6 +6089,264 @@ static inline BTLA_CODE gemv_6bit_s8s8_fp32(const utils::GemvParamA& A, const ut
           }
           b4ptr += VLen * KTILE / 2;
           b2ptr += VLen * KTILE / 4;
+        }
+      }
+    }
+
+    gemv_dequant_s32fp32<ScaleT, NReg, MTILE>(A.sptr + ib, A.ldzp, B.sptr + ib * B.ldzp, iacc, acc);
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm512_storeu_ps(C + i * VLen + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_7bit_u8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b4ptr = reinterpret_cast<utils::bit4x2*>(B.b4ptr);
+  auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+
+  int blks = k / blocksize;
+  int constexpr VLen = 16;
+  int constexpr NReg = NTILE / VLen;
+  int constexpr MReg = MTILE;
+  __m512 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm512_setzero_ps();
+  }
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm512_set1_epi8(FullRange);
+
+  auto zmm_0x04 = _mm512_set1_epi8(0x04);
+  auto zmm_0x00 = _mm512_set1_epi8(0x00);
+  const auto vindex = _mm512_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12,
+                                      12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0);
+
+    uint64_t mask0 = 0x0303030303030303;
+  auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
+  auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
+                                      15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm512_set_epi32(3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0);
+  const auto onesu8 = _mm512_set1_epi8(1);
+  int constexpr KTILE = 4;
+  for (int ib = 0; ib < blks; ib += 1) {
+    __m512i iacc[NReg * MReg];
+    __m512i bacc[NReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      iacc[i] = _mm512_setzero_si512();
+    }
+    for (int i = 0; i < NReg; i++) {
+      bacc[i] = _mm512_setzero_si512();
+    }
+    if (B.zpptr) {
+      __m512i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 16, vindex);
+        bzp[i] = _mm512_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m512i va = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm512_slli_epi32(vb1, 4);
+            vb2 = _mm512_slli_epi32(vb2, 4);
+            vb = _mm512_or_si512(vb, vb1);
+            vb = _mm512_or_si512(vb, vb2);
+            vb = _mm512_sub_epi8(vb, bzp[i]);
+            bacc[i] = _mm512_dpbusd_epi32(bacc[i], onesu8, vb);
+            iacc[i] = _mm512_dpbusd_epi32(iacc[i], va, vb);
+            b4ptr += VLen * KTILE / 2;
+            b2ptr += VLen * KTILE / 4;
+            b1ptr += VLen * KTILE / 8;
+          }
+        } else {
+          __m512i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm512_slli_epi32(vb1, 4);
+            vb2 = _mm512_slli_epi32(vb2, 4);
+            vb = _mm512_or_si512(vb, vb1);
+            vb = _mm512_or_si512(vb, vb2);
+            vb = _mm512_sub_epi8(vb, bzp[i]);
+            bacc[i] = _mm512_dpbusd_epi32(bacc[i], onesu8, vb);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm512_dpbusd_epi32(iacc[j * NReg + i], va[j], vb);
+            }
+            b4ptr += VLen * KTILE / 2;
+            b2ptr += VLen * KTILE / 4;
+            b1ptr += VLen * KTILE / 8;
+          }
+        }
+      }
+    } else {
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m512i va = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm512_slli_epi32(vb1, 4);
+            vb2 = _mm512_slli_epi32(vb2, 4);
+            vb = _mm512_or_si512(vb, vb1);
+            vb = _mm512_or_si512(vb, vb2);
+            vb = _mm512_sub_epi8(vb, vbias);
+            bacc[i] = _mm512_dpbusd_epi32(bacc[i], onesu8, vb);
+            iacc[i] = _mm512_dpbusd_epi32(iacc[i], va, vb);
+            b4ptr += VLen * KTILE / 2;
+            b2ptr += VLen * KTILE / 4;
+            b1ptr += VLen * KTILE / 8;
+          }
+        } else {
+          __m512i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb = unpack_4bits(b4ptr, vmask);
+            auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+            auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+            vb1 = _mm512_slli_epi32(vb1, 4);
+            vb2 = _mm512_slli_epi32(vb2, 4);
+            vb = _mm512_or_si512(vb, vb1);
+            vb = _mm512_or_si512(vb, vb2);
+            vb = _mm512_sub_epi8(vb, vbias);
+            bacc[i] = _mm512_dpbusd_epi32(bacc[i], onesu8, vb);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm512_dpbusd_epi32(iacc[j * NReg + i], va[j], vb);
+            }
+            b4ptr += VLen * KTILE / 2;
+            b2ptr += VLen * KTILE / 4;
+            b1ptr += VLen * KTILE / 8;
+          }
+        }
+      }
+    }
+
+    gemv_remove_zp<NReg, MReg>(A.zpptr + ib, A.ldzp, iacc, bacc);
+    gemv_dequant_s32fp32<ScaleT, NReg, MTILE>(A.sptr + ib, A.ldzp, B.sptr + ib * B.ldzp, iacc, acc);
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm512_storeu_ps(C + i * VLen + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_7bit_s8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b4ptr = reinterpret_cast<utils::bit4x2*>(B.b4ptr);
+  auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+
+  int blks = k / blocksize;
+  int constexpr VLen = 16;
+  int constexpr NReg = NTILE / VLen;
+  int constexpr MReg = MTILE;
+  __m512 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm512_setzero_ps();
+  }
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm512_set1_epi8(FullRange);
+
+  auto zmm_0x04 = _mm512_set1_epi8(0x04);
+  auto zmm_0x00 = _mm512_set1_epi8(0x00);
+  const auto vindex = _mm512_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12,
+                                      12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0);
+
+  uint64_t mask0 = 0x0303030303030303;
+  auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
+  auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
+                                      15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm512_set_epi32(3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0);
+  int constexpr KTILE = 4;
+  for (int ib = 0; ib < blks; ib += 1) {
+    __m512i iacc[NReg * MReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      iacc[i] = _mm512_setzero_si512();
+    }
+    if (B.zpptr) {
+      __m512i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 16, vindex);
+        bzp[i] = _mm512_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        __m512i va[MReg];
+        for (int i = 0; i < MReg; i++) {
+          va[i] = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+        }
+        for (int i = 0; i < NReg; i++) {
+          auto vb = unpack_4bits(b4ptr, vmask);
+          auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+          auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+          vb1 = _mm512_slli_epi32(vb1, 4);
+          vb2 = _mm512_slli_epi32(vb2, 4);
+          vb = _mm512_or_si512(vb, vb1);
+          vb = _mm512_or_si512(vb, vb2);
+          vb = _mm512_sub_epi8(vb, bzp[i]);
+          for (int j = 0; j < MReg; j++) {
+            auto vsb = _mm512_sign_epi8(vb, va[j]);
+            auto vabsa = _mm512_sign_epi8(va[j], va[j]);
+            iacc[j * NReg + i] = _mm512_dpbusd_epi32(iacc[j * NReg + i], vabsa, vsb);
+          }
+          b4ptr += VLen * KTILE / 2;
+          b2ptr += VLen * KTILE / 4;
+          b1ptr += VLen * KTILE / 8;
+        }
+      }
+    } else {
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        __m512i va[MReg];
+        for (int i = 0; i < MReg; i++) {
+          va[i] = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+        }
+        for (int i = 0; i < NReg; i++) {
+          auto vb = unpack_4bits(b4ptr, vmask);
+          auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+          auto vb2 = unpack_2bits(b2ptr, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+          vb1 = _mm512_slli_epi32(vb1, 4);
+          vb2 = _mm512_slli_epi32(vb2, 4);
+          vb = _mm512_or_si512(vb, vb1);
+          vb = _mm512_or_si512(vb, vb2);
+          vb = _mm512_sub_epi8(vb, vbias);
+          for (int j = 0; j < MReg; j++) {
+            auto vsb = _mm512_sign_epi8(vb, va[j]);
+            auto vabsa = _mm512_sign_epi8(va[j], va[j]);
+            iacc[j * NReg + i] = _mm512_dpbusd_epi32(iacc[j * NReg + i], vabsa, vsb);
+          }
+          b4ptr += VLen * KTILE / 2;
+          b2ptr += VLen * KTILE / 4;
+          b1ptr += VLen * KTILE / 8;
         }
       }
     }

--- a/bestla/bestla/kernel_avx512f.h
+++ b/bestla/bestla/kernel_avx512f.h
@@ -2594,7 +2594,7 @@ template <int PackRow, int NTILE>
 inline BTLA_CODE decompress_kblock_s4_s8(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                          int n_offset, int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::int4x2 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -2816,7 +2816,7 @@ static inline BTLA_CODE decompress_kblock_s2_s8(utils::bit2x4* bit2ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -3074,7 +3074,7 @@ static inline BTLA_CODE decompress_kblock_s3_s8(utils::bit2x4* bit2ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -3325,7 +3325,7 @@ static inline BTLA_CODE decompress_kblock_s5_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -3359,6 +3359,321 @@ static inline BTLA_CODE decompress_kblock_s5_s8(utils::bit4x2* bit4ptr, utils::b
   } else {
     size_t elesize = static_cast<size_t>(row) * col;
     return decompress_s5_s8(bit4ptr, bit1ptr, dstptr, elesize, tmp, tmpsize);
+  }
+  return BTLA_CODE::Success;
+}
+
+static inline BTLA_CODE decompress_s7_s8(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
+                                         int8_t* dstptr, size_t unpack_elt, int8_t* tmp, size_t tmpsize) {
+  int constexpr VBits = 512;
+  int constexpr VElt = VBits / 8;
+  int i = 0;
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm512_set1_epi8(FullRange);
+
+  uint64_t mask0 = 0x0303030303030303;
+  auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
+  auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
+                                      15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm512_set_epi32(3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0);
+
+  auto zmm_0x04 = _mm512_set1_epi8(0x04);
+  auto zmm_0x00 = _mm512_set1_epi8(0x00);
+  int elt_pad = utils::padto_le(unpack_elt, VElt);
+  for (; i < elt_pad; i += VElt) {
+    auto vout = unpack_4bits(bit4ptr + i / 2, vmask);
+    auto vb1 = unpack_1bits(bit1ptr + i / 8, zmm_0x00, zmm_0x04);
+    auto vb2 = unpack_2bits(bit2ptr + i / 4, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+    vb1 = _mm512_slli_epi32(vb1, 4);
+    vb2 = _mm512_slli_epi32(vb2, 4);
+    vout = _mm512_or_si512(vout, vb1);
+    vout = _mm512_or_si512(vout, vb2);
+    vout = _mm512_sub_epi8(vout, vbias);
+    _mm512_storeu_si512((__m512i*)(dstptr + i), vout);
+  }
+  if (elt_pad < unpack_elt) {
+    if (unpack_elt >= VElt) {
+      i = unpack_elt - VElt;
+      auto vout = unpack_4bits(bit4ptr + i / 2, vmask);
+      auto vb1 = unpack_1bits(bit1ptr + i / 8, zmm_0x00, zmm_0x04);
+      auto vb2 = unpack_2bits(bit2ptr + i / 4, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+      vb1 = _mm512_slli_epi32(vb1, 4);
+      vb2 = _mm512_slli_epi32(vb2, 4);
+      vout = _mm512_or_si512(vout, vb1);
+      vout = _mm512_or_si512(vout, vb2);
+      vout = _mm512_sub_epi8(vout, vbias);
+      _mm512_storeu_si512((__m512i*)(dstptr + i), vout);
+    } else {
+      ref::decompress_s7_s8(bit4ptr + i / 2, bit2ptr + i / 4, bit1ptr + i / 8, dstptr + i, unpack_elt - i, tmp,
+                            tmpsize);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int NTILE>
+static inline BTLA_CODE decompress_kblock_s7_s8_pack1_row(utils::bit4x2* srcptr, utils::bit2x4* bit2ptr,
+                                                          utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+                                                          int blocksize, int ldzp, int n_offset, int k_offset, int row,
+                                                          int8_t* tmp, size_t tmpsize) {
+  int constexpr VLen = 16;
+  int constexpr NReg = NTILE / VLen;
+  static_assert((NTILE % VLen) == 0);
+  int constexpr PackRow = 1;
+  int constexpr Unroll = 4;
+  __m512i v_zp_y[NReg];
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm512_set1_epi8(FullRange);
+
+  uint64_t mask0 = 0x0303030303030303;
+  auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
+  auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
+                                      15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm512_set_epi32(3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0);
+
+  auto zmm_0x04 = _mm512_set1_epi8(0x04);
+  auto zmm_0x00 = _mm512_set1_epi8(0x00);
+  for (int ir = 0; ir < row; ir += blocksize) {
+    auto zptr = zpptr + (k_offset + ir) / blocksize * ldzp + n_offset;
+    for (int i = 0; i < Unroll; i++) {
+      memcpy(tmp + i * NTILE, zptr, NTILE * sizeof(int8_t));
+    }
+    for (int i = 0; i < NReg; i++) {
+      v_zp_y[i] = _mm512_loadu_si512((const __m512i*)(tmp + i * 64));
+      v_zp_y[i] = _mm512_add_epi8(v_zp_y[i], vbias);
+    }
+    int k_remain = utils::remainsize(ir, row, blocksize);
+    int k_remain_unrll = utils::padto_le(k_remain, Unroll);
+    int ib = 0;
+    for (; ib < k_remain_unrll; ib += Unroll) {
+      auto b4ptr = srcptr + (ir + ib) * NTILE / 2;
+      auto b1ptr = bit1ptr + (ir + ib) * NTILE / 8;
+      auto b2ptr = bit2ptr + (ir + ib) * NTILE / 4;
+      for (int i = 0; i < NReg; i++) {
+        auto v_s8_y = unpack_4bits(b4ptr + i * 32, vmask);
+        auto vb1 = unpack_1bits(b1ptr + i * 8, zmm_0x00, zmm_0x04);
+        auto vb2 = unpack_2bits(b2ptr + i * 16, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+        vb1 = _mm512_slli_epi32(vb1, 4);
+        vb2 = _mm512_slli_epi32(vb2, 4);
+        v_s8_y = _mm512_or_si512(v_s8_y, vb1);
+        v_s8_y = _mm512_or_si512(v_s8_y, vb2);
+        v_s8_y = _mm512_sub_epi8(v_s8_y, v_zp_y[i]);
+        _mm512_storeu_si512((__m512i*)(dstptr + i * 64 + (ir + ib) * NTILE), v_s8_y);
+      }
+    }
+
+    int k_tail = k_remain - k_remain_unrll;
+    if (k_tail > 0) {
+      auto tmpb4ptr = tmp;
+      memcpy(tmpb4ptr, srcptr + (ir + ib) * NTILE / 2, k_tail * NTILE / 2);
+      auto tmpb1ptr = tmp + Unroll * NTILE / 2;
+      memcpy(tmpb1ptr, bit1ptr + (ir + ib) * NTILE / 8, k_tail * NTILE / 8);
+      auto tmpb2ptr = tmp + Unroll * NTILE * 3 / 4;
+      memcpy(tmpb2ptr, bit2ptr + (ir + ib) * NTILE / 4, k_tail * NTILE / 4);
+      auto tmpout = tmp + Unroll * NTILE;
+      for (int i = 0; i < NReg; i++) {
+        auto v_s8_y = unpack_4bits((utils::bit2x4*)(tmpb4ptr + i * 32), vmask);
+        auto vb1 = unpack_1bits((utils::bit1x8*)(tmpb1ptr + i * 8), zmm_0x00, zmm_0x04);
+        auto vb2 = unpack_2bits((utils::bit2x4*)(tmpb2ptr + i * 16), vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+        vb1 = _mm512_slli_epi32(vb1, 4);
+        vb2 = _mm512_slli_epi32(vb2, 4);
+        v_s8_y = _mm512_or_si512(v_s8_y, vb1);
+        v_s8_y = _mm512_or_si512(v_s8_y, vb2);
+        v_s8_y = _mm512_sub_epi8(v_s8_y, v_zp_y[i]);
+        _mm512_storeu_si512((__m512i*)(tmpout + i * 64), v_s8_y);
+      }
+      memcpy(dstptr + (ir + ib) * NTILE, tmpout, k_tail * NTILE);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int NTILE>
+static inline BTLA_CODE decompress_kblock_s7_s8_pack2_row(utils::bit4x2* srcptr, utils::bit2x4* bit2ptr,
+                                                          utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+                                                          int blocksize, int ldzp, int n_offset, int k_offset, int row,
+                                                          int8_t* tmp, size_t tmpsize) {
+  int constexpr VLen = 16;
+  int constexpr NReg = NTILE / VLen;
+  static_assert((NTILE % VLen) == 0);
+  int constexpr PackRow = 1;
+  int constexpr Unroll = 4;
+  __m512i v_zp_y[NReg];
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm512_set1_epi8(FullRange);
+
+  uint64_t mask0 = 0x0303030303030303;
+  auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
+  auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
+                                      15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm512_set_epi32(3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0);
+
+  auto zmm_0x04 = _mm512_set1_epi8(0x04);
+  auto zmm_0x00 = _mm512_set1_epi8(0x00);
+
+  const auto vindex = _mm512_set_epi8(14, 14, 12, 12, 10, 10, 8, 8, 6, 6, 4, 4, 2, 2, 0, 0, 14, 14, 12, 12, 10, 10, 8,
+                                      8, 6, 6, 4, 4, 2, 2, 0, 0, 14, 14, 12, 12, 10, 10, 8, 8, 6, 6, 4, 4, 2, 2, 0, 0,
+                                      14, 14, 12, 12, 10, 10, 8, 8, 6, 6, 4, 4, 2, 2, 0, 0);
+  for (int ir = 0; ir < row; ir += blocksize) {
+    auto zptr = zpptr + (k_offset + ir) / blocksize * ldzp + n_offset;
+    memcpy(tmp, zptr, NTILE * sizeof(int8_t));
+    memcpy(tmp + NTILE, zptr, NTILE * sizeof(int8_t));
+    for (int i = 0; i < NReg; i++) {
+      v_zp_y[i] = load_zp_epi8_broadcast_epi16(tmp + i * 32, vindex);
+      v_zp_y[i] = _mm512_add_epi8(v_zp_y[i], vbias);
+    }
+    int k_remain = utils::remainsize(ir, row, blocksize);
+    int k_remain_unrll = utils::padto_le(k_remain, PackRow * Unroll);
+    int ib = 0;
+    for (; ib < k_remain_unrll; ib += PackRow * Unroll) {
+      auto b4ptr = srcptr + (ir + ib) * NTILE / 2;
+      auto b1ptr = bit1ptr + (ir + ib) * NTILE / 8;
+      auto b2ptr = bit2ptr + (ir + ib) * NTILE / 4;
+      for (int i = 0; i < NReg; i++) {
+        auto v_s8_y = unpack_4bits(b4ptr + i * 32, vmask);
+        auto vb1 = unpack_1bits(b1ptr + i * 8, zmm_0x00, zmm_0x04);
+        auto vb2 = unpack_2bits(b2ptr + i * 16, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+        vb1 = _mm512_slli_epi32(vb1, 4);
+        vb2 = _mm512_slli_epi32(vb2, 4);
+        v_s8_y = _mm512_or_si512(v_s8_y, vb1);
+        v_s8_y = _mm512_or_si512(v_s8_y, vb2);
+        v_s8_y = _mm512_sub_epi8(v_s8_y, v_zp_y[i]);
+        _mm512_storeu_si512((__m512i*)(dstptr + i * 64 + (ir + ib) * NTILE), v_s8_y);
+      }
+    }
+    int k_tail = k_remain - k_remain_unrll;
+    if (k_tail > 0) {
+      auto tmpb4ptr = tmp;
+      memcpy(tmpb4ptr, srcptr + (ir + ib) * NTILE / 2, k_tail * NTILE / 2);
+      auto tmpb1ptr = tmp + Unroll * NTILE / 2;
+      memcpy(tmpb1ptr, bit1ptr + (ir + ib) * NTILE / 8, k_tail * NTILE / 8);
+      auto tmpb2ptr = tmp + Unroll * NTILE * 3 / 4;
+      memcpy(tmpb2ptr, bit2ptr + (ir + ib) * NTILE / 4, k_tail * NTILE / 4);
+      auto tmpout = tmp + Unroll * NTILE;
+      for (int i = 0; i < NReg; i++) {
+        auto v_s8_y = unpack_4bits((utils::bit2x4*)(tmpb4ptr + i * 32), vmask);
+        auto vb1 = unpack_1bits((utils::bit1x8*)(tmpb1ptr + i * 8), zmm_0x00, zmm_0x04);
+        auto vb2 = unpack_2bits((utils::bit2x4*)(tmpb2ptr + i * 16), vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+        vb1 = _mm512_slli_epi32(vb1, 4);
+        vb2 = _mm512_slli_epi32(vb2, 4);
+        v_s8_y = _mm512_or_si512(v_s8_y, vb1);
+        v_s8_y = _mm512_or_si512(v_s8_y, vb2);
+        v_s8_y = _mm512_sub_epi8(v_s8_y, v_zp_y[i]);
+        _mm512_storeu_si512((__m512i*)(tmpout + i * 64), v_s8_y);
+      }
+      memcpy(dstptr + (ir + ib) * NTILE, tmpout, k_tail * NTILE);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int NTILE>
+static inline BTLA_CODE decompress_kblock_s7_s8_pack4_row(utils::bit4x2* srcptr, utils::bit2x4* bit2ptr,
+                                                          utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+                                                          int blocksize, int ldzp, int n_offset, int k_offset, int row,
+                                                          int8_t* tmp, size_t tmpsize) {
+  int constexpr VLen = 16;
+  int constexpr NReg = NTILE / VLen;
+  static_assert((NTILE % VLen) == 0);
+  int constexpr PackRow = 4;
+  __m512i v_zp_y[NReg];
+  int constexpr FullRange = 1 << (7 - 1);
+  uint32_t mask = 0x0f0f0f0f;
+  auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));
+  auto vbias = _mm512_set1_epi8(FullRange);
+
+  uint64_t mask0 = 0x0303030303030303;
+  auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
+  auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
+  auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
+                                      13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
+                                      15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0);
+  auto vorder_y = _mm512_set_epi32(3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0);
+
+  auto zmm_0x04 = _mm512_set1_epi8(0x04);
+  auto zmm_0x00 = _mm512_set1_epi8(0x00);
+  const auto vindex = _mm512_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12,
+                                      12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0);
+  for (int ir = 0; ir < row; ir += blocksize) {
+    auto zptr = zpptr + (k_offset + ir) / blocksize * ldzp + n_offset;
+    for (int i = 0; i < NReg; i++) {
+      v_zp_y[i] = load_zp_epi8_broadcast_epi32(zptr + i * 16, vindex);
+      v_zp_y[i] = _mm512_add_epi8(v_zp_y[i], vbias);
+    }
+    int k_remain = utils::remainsize(ir, row, blocksize);
+    for (int ib = 0; ib < k_remain; ib += PackRow) {
+      auto b4ptr = srcptr + (ir + ib) * NTILE / 2;
+      auto b1ptr = bit1ptr + (ir + ib) * NTILE / 8;
+      auto b2ptr = bit2ptr + (ir + ib) * NTILE / 4;
+      for (int i = 0; i < NReg; i++) {
+        auto v_s8_y = unpack_4bits(b4ptr + i * 32, vmask);
+        auto vb1 = unpack_1bits(b1ptr + i * 8, zmm_0x00, zmm_0x04);
+        auto vb2 = unpack_2bits(b2ptr + i * 16, vshift_y, vmask0, vsfhl_mask_y, vorder_y);
+        vb1 = _mm512_slli_epi32(vb1, 4);
+        vb2 = _mm512_slli_epi32(vb2, 4);
+        v_s8_y = _mm512_or_si512(v_s8_y, vb1);
+        v_s8_y = _mm512_or_si512(v_s8_y, vb2);
+        v_s8_y = _mm512_sub_epi8(v_s8_y, v_zp_y[i]);
+        _mm512_storeu_si512((__m512i*)(dstptr + i * 64 + (ir + ib) * NTILE), v_s8_y);
+      }
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int PackRow, int NTILE>
+static inline BTLA_CODE decompress_kblock_s7_s8(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
+                                                int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset,
+                                                int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
+  if (zpptr) {
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
+                                    int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
+                                    int row, int8_t* tmp, size_t tmpsize);
+    decompfunc func = nullptr;
+    if (col == NTILE) {
+      if constexpr (PackRow == 1) {
+        func = &decompress_kblock_s7_s8_pack1_row<NTILE>;
+      }
+      if constexpr (PackRow == 2) {
+        func = &decompress_kblock_s7_s8_pack2_row<NTILE>;
+      }
+      if constexpr (PackRow == 4) {
+        func = &decompress_kblock_s7_s8_pack4_row<NTILE>;
+      }
+      if (func) {
+        int head_end = utils::padto(k_offset, blocksize);
+        head_end = std::min(head_end, k_offset + row);
+        int head_size = head_end - k_offset;
+        if (head_size > 0) {
+          (*func)(bit4ptr, bit2ptr, bit1ptr, zpptr, dstptr, blocksize, ldzp, n_offset, k_offset, head_size, tmp,
+                  tmpsize);
+        }
+        int body_size = row - head_size;
+        if (body_size > 0) {
+          (*func)(bit4ptr + head_size * NTILE / 2, bit2ptr + head_size * NTILE / 4, bit1ptr + head_size * NTILE / 8,
+                  zpptr, dstptr + head_size * NTILE, blocksize, ldzp, n_offset, head_end, body_size, tmp, tmpsize);
+        }
+        return BTLA_CODE::Success;
+      }
+    }
+    assert(0);
+    return BTLA_CODE::NotSupport;
+  } else {
+    size_t elesize = static_cast<size_t>(row) * col;
+    return decompress_s7_s8(bit4ptr, bit2ptr, bit1ptr, dstptr, elesize, tmp, tmpsize);
   }
   return BTLA_CODE::Success;
 }
@@ -3595,7 +3910,7 @@ static inline BTLA_CODE decompress_kblock_s6_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;

--- a/bestla/bestla/kernel_ref.h
+++ b/bestla/bestla/kernel_ref.h
@@ -223,6 +223,65 @@ static inline BTLA_CODE compress_3bit_align128(const int8_t* srcptr, bestla::uti
   return BTLA_CODE::Success;
 }
 
+static inline BTLA_CODE compress_7bit(const int8_t* srcptr, bestla::utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr,
+                                      utils::bit1x8* bit1ptr, size_t size) {
+  assert(size % 8 == 0);
+  int8_t constexpr FullRange = 1 << (7 - 1);
+  for (int j = 0; j < size; j += 8) {
+    auto tmp = srcptr[j + 0] + FullRange;
+    bit4ptr[j / 2 + 0].x = tmp & 0xf;
+    tmp = tmp >> 4;
+    bit2ptr[j / 4].a = tmp & 0x3;
+    tmp = tmp >> 2;
+    bit1ptr[j / 8].a = tmp;
+    tmp = srcptr[j + 1] + FullRange;
+    bit4ptr[j / 2 + 0].y = tmp & 0xf;
+    tmp = tmp >> 4;
+    bit2ptr[j / 4].b = tmp & 0x3;
+    tmp = tmp >> 2;
+    bit1ptr[j / 8].b = tmp;
+    tmp = srcptr[j + 2] + FullRange;
+    bit4ptr[j / 2 + 1].x = tmp & 0xf;
+    tmp = tmp >> 4;
+    bit2ptr[j / 4].c = tmp & 0x3;
+    tmp = tmp >> 2;
+    bit1ptr[j / 8].c = tmp;
+    tmp = srcptr[j + 3] + FullRange;
+    bit4ptr[j / 2 + 1].y = tmp & 0xf;
+    tmp = tmp >> 4;
+    bit2ptr[j / 4].d = tmp & 0x3;
+    tmp = tmp >> 2;
+    bit1ptr[j / 8].d = tmp;
+
+    tmp = srcptr[j + 4] + FullRange;
+    bit4ptr[j / 2 + 2].x = tmp & 0xf;
+    tmp = tmp >> 4;
+    bit2ptr[j / 4 + 1].a = tmp & 0x3;
+    tmp = tmp >> 2;
+    bit1ptr[j / 8].e = tmp;
+    tmp = srcptr[j + 5] + FullRange;
+    bit4ptr[j / 2 + 2].y = tmp & 0xf;
+    tmp = tmp >> 4;
+    bit2ptr[j / 4 + 1].b = tmp & 0x3;
+    tmp = tmp >> 2;
+    bit1ptr[j / 8].f = tmp;
+    tmp = srcptr[j + 6] + FullRange;
+    bit4ptr[j / 2 + 3].x = tmp & 0xf;
+    tmp = tmp >> 4;
+    bit2ptr[j / 4 + 1].c = tmp & 0x3;
+    tmp = tmp >> 2;
+    bit1ptr[j / 8].g = tmp;
+    tmp = srcptr[j + 7] + FullRange;
+    bit4ptr[j / 2 + 3].y = tmp & 0xf;
+    tmp = tmp >> 4;
+    bit2ptr[j / 4 + 1].d = tmp & 0x3;
+    tmp = tmp >> 2;
+    bit1ptr[j / 8].f = tmp;
+  }
+
+  return BTLA_CODE::Success;
+}
+
 static inline BTLA_CODE compress_6bit(const int8_t* srcptr, bestla::utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr,
                                       size_t size) {
   assert(size % 4 == 0);
@@ -421,6 +480,29 @@ static inline BTLA_CODE decompress_s5_s8(utils::bit4x2* bit4ptr, utils::bit1x8* 
   return BTLA_CODE::Success;
 }
 
+static inline BTLA_CODE decompress_s7_s8(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
+                                         int8_t* dstptr, int unpack_elt, int8_t* tmp, size_t tmpsize) {
+  int constexpr FullRange = 1 << (7 - 1);
+  for (size_t i = 0; i < unpack_elt; i += 8) {
+    auto bit2 = bit2ptr[i / 4];
+    auto bit1 = bit1ptr[i / 8];
+    auto tmp = bit4ptr[i / 2];
+    dstptr[i + 0] = (tmp.x | (bit2.a << 4) | (bit1.a << 6)) - FullRange;
+    dstptr[i + 1] = (tmp.y | (bit2.b << 4) | (bit1.b << 6)) - FullRange;
+    tmp = bit4ptr[i / 2 + 1];
+    dstptr[i + 2] = (tmp.x | (bit2.c << 4) | (bit1.c << 6)) - FullRange;
+    dstptr[i + 3] = (tmp.y | (bit2.d << 4) | (bit1.d << 6)) - FullRange;
+    bit2 = bit2ptr[i / 4 + 1];
+    tmp = bit4ptr[i / 2 + 2];
+    dstptr[i + 4] = (tmp.x | (bit2.a << 4) | (bit1.e << 6)) - FullRange;
+    dstptr[i + 5] = (tmp.y | (bit2.b << 4) | (bit1.f << 6)) - FullRange;
+    tmp = bit4ptr[i / 2 + 3];
+    dstptr[i + 6] = (tmp.x | (bit2.c << 4) | (bit1.g << 6)) - FullRange;
+    dstptr[i + 7] = (tmp.y | (bit2.d << 4) | (bit1.h << 6)) - FullRange;
+  }
+  return BTLA_CODE::Success;
+}
+
 static inline BTLA_CODE decompress_s4_s8(utils::int4x2* srcptr, int8_t* dstptr, size_t unpackelt, int8_t* tmp,
                                          size_t tmpsize) {
   for (int j = 0; j < unpackelt; j += 2) {
@@ -457,6 +539,92 @@ static inline BTLA_CODE decompress_s2_s8(utils::bit2x4* srcptr, int8_t* dstptr, 
     dstptr[j + 1] = tmp.b - 2;
     dstptr[j + 2] = tmp.c - 2;
     dstptr[j + 3] = tmp.d - 2;
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int PackRow, int NTILE>
+static inline BTLA_CODE decompress_kblock_s7_s8(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
+                                                int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset,
+                                                int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
+  int constexpr FullRange = 1 << (7 - 1);
+  static_assert(NTILE % 8 == 0);
+  assert(((col * PackRow) % 8) == 0);
+  if (zpptr) {
+    if constexpr (PackRow == 4) {
+      for (int i = 0; i < row; i += PackRow) {
+        auto zptr = zpptr + (i + k_offset) / blocksize * ldzp + n_offset;
+        for (int j = 0; j < col; j += 2) {
+          auto zp = zptr[j] + FullRange;
+          auto bit1 = bit1ptr[(i * col + j * PackRow) / 8];
+          auto bit2 = bit2ptr[(i * col + j * PackRow) / 4];
+          auto tmp = bit4ptr[(i * col + j * PackRow) / 2];
+          dstptr[i * col + j * PackRow + 0] = (tmp.x | (bit2.a << 4) | (bit1.a << 6)) - zp;
+          dstptr[i * col + j * PackRow + 1] = (tmp.y | (bit2.b << 4) | (bit1.b << 6)) - zp;
+          tmp = bit4ptr[(i * col + j * PackRow) / 2 + 1];
+          dstptr[i * col + j * PackRow + 2] = (tmp.x | (bit2.c << 4) | (bit1.c << 6)) - zp;
+          dstptr[i * col + j * PackRow + 3] = (tmp.y | (bit2.d << 4) | (bit1.d << 6)) - zp;
+          zp = zptr[j + 1] + FullRange;
+          bit2 = bit2ptr[(i * col + j * PackRow) / 4 + 1];
+          tmp = bit4ptr[(i * col + j * PackRow) / 2 + 2];
+          dstptr[i * col + j * PackRow + 4] = (tmp.x | (bit2.a << 4) | (bit1.e << 6)) - zp;
+          dstptr[i * col + j * PackRow + 5] = (tmp.y | (bit2.b << 4) | (bit1.f << 6)) - zp;
+          tmp = bit4ptr[(i * col + j * PackRow) / 2 + 3];
+          dstptr[i * col + j * PackRow + 6] = (tmp.x | (bit2.c << 4) | (bit1.g << 6)) - zp;
+          dstptr[i * col + j * PackRow + 7] = (tmp.y | (bit2.d << 4) | (bit1.h << 6)) - zp;
+        }
+      }
+    } else if constexpr (PackRow == 1) {
+      for (int i = 0; i < row; i += 1) {
+        auto zptr = zpptr + (i + k_offset) / blocksize * ldzp + n_offset;
+        for (int j = 0; j < col; j += 8) {
+          auto bit2 = bit2ptr[(i * col + j * PackRow) / 4];
+          auto bit1 = bit1ptr[(i * col + j * PackRow) / 8];
+          auto tmp = bit4ptr[(i * col + j * PackRow) / 2];
+          dstptr[i * col + j * PackRow + 0] = (tmp.x | (bit2.a << 4) | (bit1.a << 6)) - FullRange - zptr[j + 0];
+          dstptr[i * col + j * PackRow + 1] = (tmp.y | (bit2.b << 4) | (bit1.b << 6)) - FullRange - zptr[j + 1];
+          tmp = bit4ptr[(i * col + j * PackRow) / 2 + 1];
+          dstptr[i * col + j * PackRow + 2] = (tmp.x | (bit2.c << 4) | (bit1.c << 6)) - FullRange - zptr[j + 2];
+          dstptr[i * col + j * PackRow + 3] = (tmp.y | (bit2.d << 4) | (bit1.d << 6)) - FullRange - zptr[j + 3];
+          bit2 = bit2ptr[(i * col + j * PackRow) / 4 + 1];
+          tmp = bit4ptr[(i * col + j * PackRow) / 2 + 2];
+          dstptr[i * col + j * PackRow + 4] = (tmp.x | (bit2.a << 4) | (bit1.e << 6)) - FullRange - zptr[j + 4];
+          dstptr[i * col + j * PackRow + 5] = (tmp.y | (bit2.b << 4) | (bit1.f << 6)) - FullRange - zptr[j + 5];
+          tmp = bit4ptr[(i * col + j * PackRow) / 2 + 3];
+          dstptr[i * col + j * PackRow + 6] = (tmp.x | (bit2.c << 4) | (bit1.g << 6)) - FullRange - zptr[j + 6];
+          dstptr[i * col + j * PackRow + 7] = (tmp.y | (bit2.d << 4) | (bit1.h << 6)) - FullRange - zptr[j + 7];
+        }
+      }
+    } else if constexpr (PackRow == 2) {
+      for (int i = 0; i < row; i += PackRow) {
+        auto zptr = zpptr + (i + k_offset) / blocksize * ldzp + n_offset;
+        for (int j = 0; j < col; j += 4) {
+          auto bit2 = bit2ptr[(i * col + j * PackRow) / 4];
+          auto bit1 = bit1ptr[(i * col + j * PackRow) / 8];
+          auto tmp = bit4ptr[(i * col + j * PackRow) / 2];
+          auto zp = zptr[j] + FullRange;
+          dstptr[i * col + j * PackRow + 0] = (tmp.x | (bit2.a << 4) | (bit1.a << 6)) - zp;
+          dstptr[i * col + j * PackRow + 1] = (tmp.y | (bit2.b << 4) | (bit1.b << 6)) - zp;
+          zp = zptr[j + 1] + FullRange;
+          tmp = bit4ptr[(i * col + j * PackRow) / 2 + 1];
+          dstptr[i * col + j * PackRow + 2] = (tmp.x | (bit2.c << 4) | (bit1.c << 6)) - zp;
+          dstptr[i * col + j * PackRow + 3] = (tmp.y | (bit2.d << 4) | (bit1.d << 6)) - zp;
+          bit2 = bit2ptr[(i * col + j * PackRow) / 4 + 1];
+          zp = zptr[j + 2] + FullRange;
+          tmp = bit4ptr[(i * col + j * PackRow) / 2 + 2];
+          dstptr[i * col + j * PackRow + 4] = (tmp.x | (bit2.a << 4) | (bit1.e << 6)) - zp;
+          dstptr[i * col + j * PackRow + 5] = (tmp.y | (bit2.b << 4) | (bit1.f << 6)) - zp;
+          zp = zptr[j + 3] + FullRange;
+          tmp = bit4ptr[(i * col + j * PackRow) / 2 + 3];
+          dstptr[i * col + j * PackRow + 6] = (tmp.x | (bit2.c << 4) | (bit1.g << 6)) - zp;
+          dstptr[i * col + j * PackRow + 7] = (tmp.y | (bit2.d << 4) | (bit1.h << 6)) - zp;
+        }
+      }
+    } else {
+      static_assert(PackRow == 1 || PackRow == 2 || PackRow == 4);
+    }
+  } else {
+    return decompress_s7_s8(bit4ptr, bit2ptr, bit1ptr, dstptr, size_t(row) * col, tmp, tmpsize);
   }
   return BTLA_CODE::Success;
 }
@@ -831,6 +999,24 @@ inline BTLA_CODE decompress_kblock_s8_fp(int8_t* srcptr, DST_T* dstptr, int row,
       }
     }
   }
+  return BTLA_CODE::Success;
+}
+
+template <int PackRow, int NTILE, typename DST_T>
+static inline BTLA_CODE decompress_kblock_s7_fp(utils::bit4x2* b4ptr, utils::bit2x4* b2ptr, utils::bit1x8* b1ptr,
+                                                DST_T* dstptr, int row, int col, void* scales_, BTLA_DTYPE sdtype,
+                                                int8_t* zero_points, int k_offset, int n_offset, int blocksize,
+                                                int ldzp, int8_t* tmp, size_t tmpsize) {
+  assert(tmpsize >= PackRow * NTILE);
+  assert(NTILE == col);
+  const auto DstSize = row * NTILE * sizeof(DST_T);
+  const auto S8Size = row * NTILE * sizeof(int8_t);
+  auto tmps8ptr = (int8_t*)dstptr;
+  tmps8ptr += DstSize - S8Size;
+  decompress_kblock_s7_s8<PackRow, NTILE>(b4ptr, b2ptr, b1ptr, zero_points, tmps8ptr, blocksize, ldzp, n_offset,
+                                          k_offset, row, col, tmp, tmpsize);
+  decompress_kblock_s8_fp<PackRow, NTILE>(tmps8ptr, dstptr, row, col, scales_, sdtype, nullptr, k_offset, n_offset,
+                                          blocksize, ldzp, tmp, tmpsize);
   return BTLA_CODE::Success;
 }
 
@@ -1445,6 +1631,7 @@ static inline BTLA_CODE quantize_f32_sign_int_rowblock(const float* srcptr, int8
         case BTLA_DTYPE::S4_CLIP:
         case BTLA_DTYPE::S5_CLIP:
         case BTLA_DTYPE::S6_CLIP:
+        case BTLA_DTYPE::S7_CLIP:
           if (zero_points == nullptr) {
             sNauto_calc_store_scale_and_quantv_sym(blocksize);
           } else {

--- a/bestla/bestla/kernel_ref.h
+++ b/bestla/bestla/kernel_ref.h
@@ -3078,6 +3078,135 @@ static inline BTLA_CODE gemv_5bit_s8s8_fp32(const utils::GemvParamA& A, const ut
   }
   return BTLA_CODE::Success;
 }
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_7bit_fp32_fp32(const float* A, int lda, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  int blks = k / blocksize;
+  float accf[NTILE * MTILE];
+  std::memset(accf, 0, sizeof(accf));
+  auto b4ptr = reinterpret_cast<utils::bit4x2*>(B.b4ptr);
+  auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+  int constexpr KTILE = 1;
+  int constexpr Unroll = 4;
+  assert((blocksize % 4) == 0);
+  assert(tmpsize >= NTILE * Unroll);
+  int8_t UnpackBuf[NTILE * Unroll];
+  for (int ib = 0; ib < blks; ib += 1) {
+    auto bsptr = B.sptr + ib * B.ldzp;
+    auto bzptr = B.zpptr + ib * B.ldzp;
+    for (int ik = 0; ik < blocksize; ik += Unroll) {
+      decompress_kblock_s7_s8<1, NTILE>(b4ptr, b2ptr, b1ptr, B.zpptr ? bzptr : nullptr, UnpackBuf, blocksize, B.ldzp, 0,
+                                        0, Unroll, NTILE, tmp, tmpsize);
+      for (int im = 0; im < MTILE; im++) {
+        for (int in = 0; in < NTILE; in++) {
+          for (int ikt = 0; ikt < Unroll; ikt++) {
+            auto bval = (UnpackBuf[in + ikt * NTILE]) * bsptr[in];
+            auto aval = A[ikt + im * lda];
+            accf[im * NTILE + in] += aval * bval;
+          }
+        }
+      }
+      b4ptr += Unroll * NTILE / 2;
+      b2ptr += Unroll * NTILE / 4;
+      b1ptr += Unroll * NTILE / 8;
+      A += Unroll;
+    }
+  }
+  for (int im = 0; im < MTILE; im++) {
+    for (int in = 0; in < NTILE; in++) {
+      C[in + im * ldc] = accf[im * NTILE + in];
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_7bit_u8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  int blks = k / blocksize;
+  float accf[NTILE * MTILE];
+  std::memset(accf, 0, sizeof(accf));
+  auto a8ptr = A.aptr;
+  auto b4ptr = reinterpret_cast<utils::bit4x2*>(B.b4ptr);
+  auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+  int constexpr KTILE = 4;
+  int8_t UnpackBuf[NTILE * KTILE];
+  for (int ib = 0; ib < blks; ib += 1) {
+    auto bsptr = B.sptr + ib * B.ldzp;
+    auto bzptr = B.zpptr + ib * B.ldzp;
+    for (int ik = 0; ik < blocksize; ik += KTILE) {
+      decompress_kblock_s7_s8<4, NTILE>(b4ptr, b2ptr, b1ptr, B.zpptr ? bzptr : nullptr, UnpackBuf, blocksize, B.ldzp, 0,
+                                        0, KTILE, NTILE, tmp, tmpsize);
+      for (int im = 0; im < MTILE; im++) {
+        float ascale = A.sptr[ib + im * A.ldzp];
+        auto azp = A.zpptr[ib + im * A.ldzp];
+        for (int in = 0; in < NTILE; in++) {
+          for (int ikt = 0; ikt < KTILE; ikt++) {
+            auto bval = (UnpackBuf[in * KTILE + ikt]) * bsptr[in];
+            auto aval = int(a8ptr[ikt + im * A.lda] - azp) * ascale;
+            accf[im * NTILE + in] += aval * bval;
+          }
+        }
+      }
+      b4ptr += KTILE * NTILE / 2;
+      b2ptr += KTILE * NTILE / 4;
+      b1ptr += KTILE * NTILE / 8;
+      a8ptr += KTILE;
+    }
+  }
+  for (int im = 0; im < MTILE; im++) {
+    for (int in = 0; in < NTILE; in++) {
+      C[in + im * ldc] = accf[im * NTILE + in];
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_7bit_s8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  int blks = k / blocksize;
+  float accf[NTILE * MTILE];
+  std::memset(accf, 0, sizeof(accf));
+  auto a8ptr = (int8_t*)A.aptr;
+  auto b4ptr = reinterpret_cast<utils::bit4x2*>(B.b4ptr);
+  auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+  int constexpr KTILE = 4;
+  int8_t UnpackBuf[NTILE * KTILE];
+  for (int ib = 0; ib < blks; ib += 1) {
+    auto bsptr = B.sptr + ib * B.ldzp;
+    auto bzptr = B.zpptr + ib * B.ldzp;
+    for (int ik = 0; ik < blocksize; ik += KTILE) {
+      decompress_kblock_s7_s8<4, NTILE>(b4ptr, b2ptr, b1ptr, B.zpptr ? bzptr : nullptr, UnpackBuf, blocksize, B.ldzp, 0,
+                                        0, KTILE, NTILE, tmp, tmpsize);
+      for (int im = 0; im < MTILE; im++) {
+        float ascale = A.sptr[ib + im * A.ldzp];
+        for (int in = 0; in < NTILE; in++) {
+          for (int ikt = 0; ikt < KTILE; ikt++) {
+            auto bval = (UnpackBuf[in * KTILE + ikt]) * bsptr[in];
+            auto aval = int(a8ptr[ikt + im * A.lda]) * ascale;
+            accf[im * NTILE + in] += aval * bval;
+          }
+        }
+      }
+      b4ptr += KTILE * NTILE / 2;
+      b2ptr += KTILE * NTILE / 4;
+      b1ptr += KTILE * NTILE / 8;
+      a8ptr += KTILE;
+    }
+  }
+  for (int im = 0; im < MTILE; im++) {
+    for (int in = 0; in < NTILE; in++) {
+      C[in + im * ldc] = accf[im * NTILE + in];
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
 }  // namespace ref
 }  // namespace kernel
 }  // namespace bestla

--- a/bestla/bestla/kernel_ref.h
+++ b/bestla/bestla/kernel_ref.h
@@ -276,7 +276,7 @@ static inline BTLA_CODE compress_7bit(const int8_t* srcptr, bestla::utils::bit4x
     tmp = tmp >> 4;
     bit2ptr[j / 4 + 1].d = tmp & 0x3;
     tmp = tmp >> 2;
-    bit1ptr[j / 8].f = tmp;
+    bit1ptr[j / 8].h = tmp;
   }
 
   return BTLA_CODE::Success;

--- a/bestla/bestla/kernel_wrapper.h
+++ b/bestla/bestla/kernel_wrapper.h
@@ -273,6 +273,15 @@ class CompressFp4 {
   }
 };
 
+class CompressBit7 {
+ public:
+  template <BTLA_ISA ISA_T>
+  static inline BTLA_CODE forward(const int8_t* srcptr, bestla::utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr,
+                                  utils::bit1x8* bit1ptr, size_t size) {
+    return ref::compress_7bit(srcptr, bit4ptr, bit2ptr, bit1ptr, size);
+  }
+};
+
 class CompressBit6 {
  public:
   template <BTLA_ISA ISA_T>
@@ -450,6 +459,32 @@ class DecompressKBlockS4S8 {
 };
 
 template <int PackRow, int NTILE>
+class DecompressKBlockS7S8 {
+ public:
+  template <BTLA_ISA ISA_T>
+  static inline BTLA_CODE forward(utils::bit4x2* b4ptr, utils::bit2x4* b2ptr, utils::bit1x8* b1ptr, int8_t* zpptr,
+                                  int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset, int row, int col,
+                                  void* tmp, size_t tmpsize) {
+    // #if CompileAVX512F()
+    //     if constexpr (utils::isa_base<ISA_T>::avx512f) {
+    //       return avx512f::decompress_kblock_s6_s8<PackRow, NTILE>(b4ptr, b2ptr, zpptr, dstptr, blocksize, ldzp,
+    //       n_offset,
+    //                                                               k_offset, row, col, (int8_t*)tmp, tmpsize);
+    //     }
+    // #endif
+    // #if CompileAVX2()
+    //     if constexpr (utils::isa_base<ISA_T>::avx2) {
+    //       return avx2::decompress_kblock_s6_s8<PackRow, NTILE>(b4ptr, b2ptr, zpptr, dstptr, blocksize, ldzp,
+    //       n_offset,
+    //                                                            k_offset, row, col, (int8_t*)tmp, tmpsize);
+    //     }
+    // #endif
+    return ref::decompress_kblock_s7_s8<PackRow, NTILE>(b4ptr, b2ptr, b1ptr, zpptr, dstptr, blocksize, ldzp, n_offset,
+                                                        k_offset, row, col, (int8_t*)tmp, tmpsize);
+  }
+};
+
+template <int PackRow, int NTILE>
 class DecompressKBlockS6S8 {
  public:
   template <BTLA_ISA ISA_T>
@@ -570,6 +605,37 @@ class DecompressKBlockS8Fp {
 #endif
     ret = ref::decompress_kblock_s8_fp<PackRow, NTILE, DstT>(srcptr, dstptr, row, col, scales, sdtype, zero_points,
                                                              k_offset, n_offset, kblock, NPad,
+                                                             reinterpret_cast<int8_t*>(tmp), tmpsize);
+    return ret;
+  }
+};
+
+template <int PackRow, int NTILE, typename DstT>
+class DecompressKBlockS7Fp {
+ public:
+  template <BTLA_ISA ISA_T>
+  static inline BTLA_CODE forward(utils::bit4x2* b4ptr, utils::bit2x4* b2ptr, utils::bit1x8* b1ptr, DstT* dstptr,
+                                  int row, int col, void* scales, BTLA_DTYPE sdtype, int8_t* zero_points, int k_offset,
+                                  int n_offset, int kblock, int NPad, void* tmp, size_t tmpsize) {
+    BTLA_CODE ret = BTLA_CODE::NotSupport;
+    // #if CompileAVX512F()
+    //     if constexpr (utils::isa_base<ISA_T>::avx512f) {
+    //       return avx512f::decompress_kblock_s6_fp<PackRow, NTILE, DstT>(b4ptr, b2ptr, dstptr, row, col, scales,
+    //       sdtype,
+    //                                                                     zero_points, k_offset, n_offset, kblock,
+    //                                                                     NPad, reinterpret_cast<int8_t*>(tmp),
+    //                                                                     tmpsize);
+    //     }
+    // #endif
+    // #if CompileAVX2()
+    //     if constexpr (utils::isa_base<ISA_T>::avx2) {
+    //       return avx2::decompress_kblock_s6_fp<PackRow, NTILE, DstT>(b4ptr, b2ptr, dstptr, row, col, scales, sdtype,
+    //                                                                  zero_points, k_offset, n_offset, kblock, NPad,
+    //                                                                  reinterpret_cast<int8_t*>(tmp), tmpsize);
+    //     }
+    // #endif
+    ret = ref::decompress_kblock_s7_fp<PackRow, NTILE, DstT>(b4ptr, b2ptr, b1ptr, dstptr, row, col, scales, sdtype,
+                                                             zero_points, k_offset, n_offset, kblock, NPad,
                                                              reinterpret_cast<int8_t*>(tmp), tmpsize);
     return ret;
   }

--- a/bestla/bestla/kernel_wrapper.h
+++ b/bestla/bestla/kernel_wrapper.h
@@ -1216,26 +1216,31 @@ class GEMVWoqNBits {
 #endif
       return ref::gemv_2bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
+    if (B.nbits == 7) {
+// #if CompileAVX512VNNI()
+//       if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
+//         return avx512f::vnni::gemv_6bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
+//                                                                         tmpsize);
+//       }
+// #endif
+#if CompileAVXVNNI()
+      if (ISA_T >= BTLA_ISA::AVX_VNNI) {
+        return avx2::vnni::gemv_7bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+      }
+#endif
+#if CompileAVX2()
+      if (ISA_T >= BTLA_ISA::AVX2) {
+        return avx2::gemv_7bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+      }
+#endif
+      return ref::gemv_7bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+    }
     return BTLA_CODE::NotSupport;
   }
 
   template <BTLA_ISA ISA_T, typename ScaleT, int NTILE, int MTILE>
   static inline BTLA_CODE forward_s8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
                                             int ldc, int k, int blocksize, void* tmp, size_t tmpsize) {
-    if (B.nbits == 6) {
-#if CompileAVX512VNNI()
-      if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
-        return avx512f::vnni::gemv_6bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
-                                                                        tmpsize);
-      }
-#endif
-#if CompileAVXVNNI()
-      if (ISA_T >= BTLA_ISA::AVX_VNNI) {
-        return avx2::vnni::gemv_6bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
-      }
-#endif
-      return ref::gemv_6bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
-    }
     if (B.nbits == 5) {
 #if CompileAVX512VNNI()
       if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
@@ -1291,6 +1296,34 @@ class GEMVWoqNBits {
       }
 #endif
       return ref::gemv_2bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+    }
+    if (B.nbits == 6) {
+#if CompileAVX512VNNI()
+      if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
+        return avx512f::vnni::gemv_6bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
+                                                                        tmpsize);
+      }
+#endif
+#if CompileAVXVNNI()
+      if (ISA_T >= BTLA_ISA::AVX_VNNI) {
+        return avx2::vnni::gemv_6bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+      }
+#endif
+      return ref::gemv_6bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+    }
+    if (B.nbits == 7) {
+// #if CompileAVX512VNNI()
+//       if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
+//         return avx512f::vnni::gemv_6bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
+//                                                                         tmpsize);
+//       }
+// #endif
+#if CompileAVXVNNI()
+      if (ISA_T >= BTLA_ISA::AVX_VNNI) {
+        return avx2::vnni::gemv_7bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+      }
+#endif
+      return ref::gemv_7bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
     return BTLA_CODE::NotSupport;
   }
@@ -1367,6 +1400,20 @@ class GEMVWoqNBits {
       }
 #endif
       return ref::gemv_2bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+    }
+    if (B.nbits == 7) {
+//#if CompileAVX512F()
+//      if (ISA_T >= BTLA_ISA::AVX512F) {
+//        return avx512f::gemv_6bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp,
+//                                                                  tmpsize);
+//      }
+//#endif
+#if CompileAVX2()
+      if (ISA_T >= BTLA_ISA::AVX2) {
+        return avx2::gemv_7bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+      }
+#endif
+      return ref::gemv_7bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
     return BTLA_CODE::NotSupport;
   }

--- a/bestla/bestla/kernel_wrapper.h
+++ b/bestla/bestla/kernel_wrapper.h
@@ -465,13 +465,12 @@ class DecompressKBlockS7S8 {
   static inline BTLA_CODE forward(utils::bit4x2* b4ptr, utils::bit2x4* b2ptr, utils::bit1x8* b1ptr, int8_t* zpptr,
                                   int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset, int row, int col,
                                   void* tmp, size_t tmpsize) {
-    // #if CompileAVX512F()
-    //     if constexpr (utils::isa_base<ISA_T>::avx512f) {
-    //       return avx512f::decompress_kblock_s6_s8<PackRow, NTILE>(b4ptr, b2ptr, zpptr, dstptr, blocksize, ldzp,
-    //       n_offset,
-    //                                                               k_offset, row, col, (int8_t*)tmp, tmpsize);
-    //     }
-    // #endif
+#if CompileAVX512F()
+    if constexpr (utils::isa_base<ISA_T>::avx512f) {
+      return avx512f::decompress_kblock_s7_s8<PackRow, NTILE>(b4ptr, b2ptr, b1ptr, zpptr, dstptr, blocksize, ldzp,
+                                                              n_offset, k_offset, row, col, (int8_t*)tmp, tmpsize);
+    }
+#endif
 #if CompileAVX2()
     if constexpr (utils::isa_base<ISA_T>::avx2) {
       return avx2::decompress_kblock_s7_s8<PackRow, NTILE>(b4ptr, b2ptr, b1ptr, zpptr, dstptr, blocksize, ldzp,
@@ -617,15 +616,13 @@ class DecompressKBlockS7Fp {
                                   int row, int col, void* scales, BTLA_DTYPE sdtype, int8_t* zero_points, int k_offset,
                                   int n_offset, int kblock, int NPad, void* tmp, size_t tmpsize) {
     BTLA_CODE ret = BTLA_CODE::NotSupport;
-    // #if CompileAVX512F()
-    //     if constexpr (utils::isa_base<ISA_T>::avx512f) {
-    //       return avx512f::decompress_kblock_s6_fp<PackRow, NTILE, DstT>(b4ptr, b2ptr, dstptr, row, col, scales,
-    //       sdtype,
-    //                                                                     zero_points, k_offset, n_offset, kblock,
-    //                                                                     NPad, reinterpret_cast<int8_t*>(tmp),
-    //                                                                     tmpsize);
-    //     }
-    // #endif
+#if CompileAVX512F()
+    if constexpr (utils::isa_base<ISA_T>::avx512f) {
+      return avx512f::decompress_kblock_s7_fp<PackRow, NTILE, DstT>(b4ptr, b2ptr, b1ptr, dstptr, row, col, scales,
+                                                                    sdtype, zero_points, k_offset, n_offset, kblock,
+                                                                    NPad, reinterpret_cast<int8_t*>(tmp), tmpsize);
+    }
+#endif
 #if CompileAVX2()
     if constexpr (utils::isa_base<ISA_T>::avx2) {
       return avx2::decompress_kblock_s7_fp<PackRow, NTILE, DstT>(b4ptr, b2ptr, b1ptr, dstptr, row, col, scales, sdtype,
@@ -1217,12 +1214,12 @@ class GEMVWoqNBits {
       return ref::gemv_2bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
     if (B.nbits == 7) {
-// #if CompileAVX512VNNI()
-//       if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
-//         return avx512f::vnni::gemv_6bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
-//                                                                         tmpsize);
-//       }
-// #endif
+#if CompileAVX512VNNI()
+      if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
+        return avx512f::vnni::gemv_7bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
+                                                                        tmpsize);
+      }
+#endif
 #if CompileAVXVNNI()
       if (ISA_T >= BTLA_ISA::AVX_VNNI) {
         return avx2::vnni::gemv_7bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
@@ -1312,12 +1309,12 @@ class GEMVWoqNBits {
       return ref::gemv_6bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
     if (B.nbits == 7) {
-// #if CompileAVX512VNNI()
-//       if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
-//         return avx512f::vnni::gemv_6bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
-//                                                                         tmpsize);
-//       }
-// #endif
+#if CompileAVX512VNNI()
+      if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
+        return avx512f::vnni::gemv_7bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
+                                                                        tmpsize);
+      }
+#endif
 #if CompileAVXVNNI()
       if (ISA_T >= BTLA_ISA::AVX_VNNI) {
         return avx2::vnni::gemv_7bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
@@ -1402,12 +1399,12 @@ class GEMVWoqNBits {
       return ref::gemv_2bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
     if (B.nbits == 7) {
-//#if CompileAVX512F()
-//      if (ISA_T >= BTLA_ISA::AVX512F) {
-//        return avx512f::gemv_6bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp,
-//                                                                  tmpsize);
-//      }
-//#endif
+#if CompileAVX512F()
+      if (ISA_T >= BTLA_ISA::AVX512F) {
+        return avx512f::gemv_7bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp,
+                                                                  tmpsize);
+      }
+#endif
 #if CompileAVX2()
       if (ISA_T >= BTLA_ISA::AVX2) {
         return avx2::gemv_7bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);

--- a/bestla/bestla/kernel_wrapper.h
+++ b/bestla/bestla/kernel_wrapper.h
@@ -472,13 +472,12 @@ class DecompressKBlockS7S8 {
     //                                                               k_offset, row, col, (int8_t*)tmp, tmpsize);
     //     }
     // #endif
-    // #if CompileAVX2()
-    //     if constexpr (utils::isa_base<ISA_T>::avx2) {
-    //       return avx2::decompress_kblock_s6_s8<PackRow, NTILE>(b4ptr, b2ptr, zpptr, dstptr, blocksize, ldzp,
-    //       n_offset,
-    //                                                            k_offset, row, col, (int8_t*)tmp, tmpsize);
-    //     }
-    // #endif
+#if CompileAVX2()
+    if constexpr (utils::isa_base<ISA_T>::avx2) {
+      return avx2::decompress_kblock_s7_s8<PackRow, NTILE>(b4ptr, b2ptr, b1ptr, zpptr, dstptr, blocksize, ldzp,
+                                                           n_offset, k_offset, row, col, (int8_t*)tmp, tmpsize);
+    }
+#endif
     return ref::decompress_kblock_s7_s8<PackRow, NTILE>(b4ptr, b2ptr, b1ptr, zpptr, dstptr, blocksize, ldzp, n_offset,
                                                         k_offset, row, col, (int8_t*)tmp, tmpsize);
   }
@@ -627,13 +626,13 @@ class DecompressKBlockS7Fp {
     //                                                                     tmpsize);
     //     }
     // #endif
-    // #if CompileAVX2()
-    //     if constexpr (utils::isa_base<ISA_T>::avx2) {
-    //       return avx2::decompress_kblock_s6_fp<PackRow, NTILE, DstT>(b4ptr, b2ptr, dstptr, row, col, scales, sdtype,
-    //                                                                  zero_points, k_offset, n_offset, kblock, NPad,
-    //                                                                  reinterpret_cast<int8_t*>(tmp), tmpsize);
-    //     }
-    // #endif
+#if CompileAVX2()
+    if constexpr (utils::isa_base<ISA_T>::avx2) {
+      return avx2::decompress_kblock_s7_fp<PackRow, NTILE, DstT>(b4ptr, b2ptr, b1ptr, dstptr, row, col, scales, sdtype,
+                                                                 zero_points, k_offset, n_offset, kblock, NPad,
+                                                                 reinterpret_cast<int8_t*>(tmp), tmpsize);
+    }
+#endif
     ret = ref::decompress_kblock_s7_fp<PackRow, NTILE, DstT>(b4ptr, b2ptr, b1ptr, dstptr, row, col, scales, sdtype,
                                                              zero_points, k_offset, n_offset, kblock, NPad,
                                                              reinterpret_cast<int8_t*>(tmp), tmpsize);

--- a/bestla/bestla/ut/bestla_benchmark.cpp
+++ b/bestla/bestla/ut/bestla_benchmark.cpp
@@ -441,6 +441,7 @@ class UTWOQ_CompFp32 {
  public:
   UTWOQ_CompFp32() {
     UT_START();
+    ut_s7();
     ut_s6();
     /*ut_s5();
     ut_s2();
@@ -468,6 +469,10 @@ class UTWOQ_CompFp32 {
   void ut_s6() {
     benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1, 4096, 4096, BTLA_DTYPE::S6_CLIP);
     benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S6_CLIP);
+  }
+  void ut_s7() {
+    benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1, 4096, 4096, BTLA_DTYPE::S7_CLIP);
+    benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S7_CLIP);
   }
   void ut_s8() {
     benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1, 4096, 4096, BTLA_DTYPE::S8);
@@ -686,6 +691,7 @@ class UTWOQ_CompInt8 {
  public:
   UTWOQ_CompInt8() {
     UT_START();
+    ut_s7();
     ut_s6();
     /*ut_s5();
     ut_s2();
@@ -724,18 +730,27 @@ class UTWOQ_CompInt8 {
     benchmark_all<prologue_b::gemm::WeightKBlockNInteger, float>(1, 4096, 4096, BTLA_DTYPE::S5_CLIP);
     benchmark_all<prologue_b::gemm::WeightKBlockNInteger, float>(1, 4096, 4096, BTLA_DTYPE::S5_CLIP, true);
     benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1, 4096, 4096, BTLA_DTYPE::S5_CLIP);
-    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S4_CLIP, true);
-    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S4_CLIP);
-    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(2048, 4096, 4096, BTLA_DTYPE::S4_CLIP);
+    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S5_CLIP, true);
+    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S5_CLIP);
+    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(2048, 4096, 4096, BTLA_DTYPE::S5_CLIP);
   }
 
   void ut_s6() {
     benchmark_all<prologue_b::gemm::WeightKBlockNInteger, float>(1, 4096, 4096, BTLA_DTYPE::S6_CLIP);
     benchmark_all<prologue_b::gemm::WeightKBlockNInteger, float>(1, 4096, 4096, BTLA_DTYPE::S6_CLIP, true);
     benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1, 4096, 4096, BTLA_DTYPE::S6_CLIP);
-    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S4_CLIP, true);
-    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S4_CLIP);
-    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(2048, 4096, 4096, BTLA_DTYPE::S4_CLIP);
+    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S6_CLIP, true);
+    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S6_CLIP);
+    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(2048, 4096, 4096, BTLA_DTYPE::S6_CLIP);
+  }
+
+  void ut_s7() {
+    benchmark_all<prologue_b::gemm::WeightKBlockNInteger, float>(1, 4096, 4096, BTLA_DTYPE::S7_CLIP);
+    benchmark_all<prologue_b::gemm::WeightKBlockNInteger, float>(1, 4096, 4096, BTLA_DTYPE::S7_CLIP, true);
+    benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1, 4096, 4096, BTLA_DTYPE::S7_CLIP);
+    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S7_CLIP, true);
+    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S7_CLIP);
+    // benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(2048, 4096, 4096, BTLA_DTYPE::S7_CLIP);
   }
 
   void ut_s8() {

--- a/bestla/bestla/ut/bestla_prologue_b.cpp
+++ b/bestla/bestla/ut/bestla_prologue_b.cpp
@@ -171,6 +171,9 @@ class UT_BlockQunatize_SN {
   UT_BlockQunatize_SN() {
     UT_START();
     CheckISA(AVX2);
+    ut<sAVX2>(4096, 4096, 32, BTLA_DTYPE::S7_CLIP, true);
+    ut<sAVX2>(4096, 4096, 32, BTLA_DTYPE::S7_CLIP);
+    ut<sAVX2>(4096, 4096, 128, BTLA_DTYPE::S7_CLIP);
     ut<sAVX2>(4096, 4096, 32, BTLA_DTYPE::S6_CLIP, true);
     ut<sAVX2>(4096, 4096, 32, BTLA_DTYPE::S6_CLIP);
     ut<sAVX2>(4096, 4096, 128, BTLA_DTYPE::S6_CLIP);
@@ -219,8 +222,9 @@ class UT_BlockQunatize_SN {
 };
 #ifdef BTLA_UT_PROLOGUE_B
 // no proper threshold for this UT
-// static UT_BlockQunatize_SN sUT_BlockQunatize_SN;
+// 
 #endif
+static UT_BlockQunatize_SN sUT_BlockQunatize_SN;
 
 class UT_S3_WOQ {
  public:

--- a/bestla/bestla/ut/bestla_prologue_b.cpp
+++ b/bestla/bestla/ut/bestla_prologue_b.cpp
@@ -222,9 +222,8 @@ class UT_BlockQunatize_SN {
 };
 #ifdef BTLA_UT_PROLOGUE_B
 // no proper threshold for this UT
-// 
+// static UT_BlockQunatize_SN sUT_BlockQunatize_SN;
 #endif
-static UT_BlockQunatize_SN sUT_BlockQunatize_SN;
 
 class UT_S3_WOQ {
  public:

--- a/bestla/bestla/ut/kernel_intrin.cpp
+++ b/bestla/bestla/ut/kernel_intrin.cpp
@@ -501,16 +501,42 @@ class UT_avx512_gemv {
  public:
   UT_avx512_gemv() {
     UT_START();
-    CheckISA(AVX512_VNNI);
-    ut_4bit<1>(48, 128, 32, true);
-    ut_4bit<1>(48, 128, 32, false);
-    ut_4bit<4>(48, 128, 32, false);
-    ut_4bit<4>(48, 128, 32, true);
+    CheckISA(AVX512F);
+    ut_7bit_fp32<1>(48, 128, 32, true);
+    ut_7bit_fp32<1>(48, 128, 32, false);
+    ut_7bit_fp32<4>(48, 128, 32, true);
+    ut_7bit_fp32<4>(48, 128, 32, false);
+
+    ut_6bit_fp32<1>(48, 128, 32, true);
+    ut_6bit_fp32<1>(48, 128, 32, false);
+    ut_6bit_fp32<4>(48, 128, 32, true);
+    ut_6bit_fp32<4>(48, 128, 32, false);
+
+    ut_5bit_fp32<1>(48, 128, 32, true);
+    ut_5bit_fp32<1>(48, 128, 32, false);
+    ut_5bit_fp32<4>(48, 128, 32, true);
+    ut_5bit_fp32<4>(48, 128, 32, false);
 
     ut_4bit_fp32<1>(48, 128, 32, true);
     ut_4bit_fp32<1>(48, 128, 32, false);
     ut_4bit_fp32<4>(48, 128, 32, true);
     ut_4bit_fp32<4>(48, 128, 32, false);
+
+    ut_3bit_fp32<1>(48, 128, 32, true);
+    ut_3bit_fp32<1>(48, 128, 32, false);
+    ut_3bit_fp32<4>(48, 128, 32, true);
+    ut_3bit_fp32<4>(48, 128, 32, false);
+
+    ut_2bit_fp32<1>(48, 128, 32, true);
+    ut_2bit_fp32<1>(48, 128, 32, false);
+    ut_2bit_fp32<4>(48, 128, 32, true);
+    ut_2bit_fp32<4>(48, 128, 32, false);
+
+    CheckISA(AVX512_VNNI);
+    ut_4bit<1>(48, 128, 32, true);
+    ut_4bit<1>(48, 128, 32, false);
+    ut_4bit<4>(48, 128, 32, false);
+    ut_4bit<4>(48, 128, 32, true);
 
     ut_4bit_s8s8<1>(48, 128, 32, true);
     ut_4bit_s8s8<1>(48, 128, 32, false);
@@ -527,11 +553,6 @@ class UT_avx512_gemv {
     ut_2bit_s8s8<4>(48, 128, 32, true);
     ut_2bit_s8s8<4>(48, 128, 32, false);
 
-    ut_2bit_fp32<1>(48, 128, 32, true);
-    ut_2bit_fp32<1>(48, 128, 32, false);
-    ut_2bit_fp32<4>(48, 128, 32, true);
-    ut_2bit_fp32<4>(48, 128, 32, false);
-
     ut_3bit_u8s8<1>(48, 128, 32, true);
     ut_3bit_u8s8<1>(48, 128, 32, false);
     ut_3bit_u8s8<4>(48, 128, 32, true);
@@ -541,16 +562,6 @@ class UT_avx512_gemv {
     ut_3bit_s8s8<1>(48, 128, 32, false);
     ut_3bit_s8s8<4>(48, 128, 32, true);
     ut_3bit_s8s8<4>(48, 128, 32, false);
-
-    ut_3bit_fp32<1>(48, 128, 32, true);
-    ut_3bit_fp32<1>(48, 128, 32, false);
-    ut_3bit_fp32<4>(48, 128, 32, true);
-    ut_3bit_fp32<4>(48, 128, 32, false);
-
-    ut_6bit_fp32<1>(48, 128, 32, true);
-    ut_6bit_fp32<1>(48, 128, 32, false);
-    ut_6bit_fp32<4>(48, 128, 32, true);
-    ut_6bit_fp32<4>(48, 128, 32, false);
 
     ut_6bit_u8s8<1>(48, 128, 32, true);
     ut_6bit_u8s8<1>(48, 128, 32, false);
@@ -562,11 +573,6 @@ class UT_avx512_gemv {
     ut_6bit_s8s8<4>(48, 128, 32, true);
     ut_6bit_s8s8<4>(48, 128, 32, false);
 
-    ut_5bit_fp32<1>(48, 128, 32, true);
-    ut_5bit_fp32<1>(48, 128, 32, false);
-    ut_5bit_fp32<4>(48, 128, 32, true);
-    ut_5bit_fp32<4>(48, 128, 32, false);
-
     ut_5bit_u8s8<1>(48, 128, 32, true);
     ut_5bit_u8s8<1>(48, 128, 32, false);
     ut_5bit_u8s8<4>(48, 128, 32, true);
@@ -576,6 +582,181 @@ class UT_avx512_gemv {
     ut_5bit_s8s8<1>(48, 128, 32, false);
     ut_5bit_s8s8<4>(48, 128, 32, true);
     ut_5bit_s8s8<4>(48, 128, 32, false);
+
+    ut_7bit_s8s8<1>(48, 128, 32, true);
+    ut_7bit_s8s8<1>(48, 128, 32, false);
+    ut_7bit_s8s8<4>(48, 128, 32, true);
+    ut_7bit_s8s8<4>(48, 128, 32, false);
+
+    ut_7bit_u8s8<1>(48, 128, 32, true);
+    ut_7bit_u8s8<1>(48, 128, 32, false);
+    ut_7bit_u8s8<4>(48, 128, 32, true);
+    ut_7bit_u8s8<4>(48, 128, 32, false);
+
+  }
+
+  template <int MTILE>
+  void ut_7bit_fp32(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit4x2> b4(n * k / 2);
+    avector<bit1x8> b1(n * k / 8);
+    avector<bit2x4> b2(n * k / 4);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b4.data(), b4.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b2.data(), b2.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(Af32.data(), Af32.size(), -0.5f, 0.5f);
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-64), int8_t(63));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s7_s8(b4.data(), b2.data(), b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 1) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 4) {
+        if (iasym) {
+          Bf32[(i)*n + j + 0] = (b8[(i)*n + j + 0] - bzp[bid * n + j + 0]) * scaleb[bid * n + j + 0];
+          Bf32[(i)*n + j + 1] = (b8[(i)*n + j + 1] - bzp[bid * n + j + 1]) * scaleb[bid * n + j + 1];
+          Bf32[(i)*n + j + 2] = (b8[(i)*n + j + 2] - bzp[bid * n + j + 2]) * scaleb[bid * n + j + 2];
+          Bf32[(i)*n + j + 3] = (b8[(i)*n + j + 3] - bzp[bid * n + j + 3]) * scaleb[bid * n + j + 3];
+        } else {
+          Bf32[(i)*n + j + 0] = (b8[(i)*n + j + 0]) * scaleb[bid * n + j + 0];
+          Bf32[(i)*n + j + 1] = (b8[(i)*n + j + 1]) * scaleb[bid * n + j + 1];
+          Bf32[(i)*n + j + 2] = (b8[(i)*n + j + 2]) * scaleb[bid * n + j + 2];
+          Bf32[(i)*n + j + 3] = (b8[(i)*n + j + 3]) * scaleb[bid * n + j + 3];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{(uint8_t*)b4.data(),
+                               (uint8_t*)b2.data(),
+                               (uint8_t*)b1.data(),
+                               scaleb.data(),
+                               iasym ? bzp.data() : nullptr,
+                               7,
+                               n};
+    kernel::avx512f::gemv_7bit_fp32_fp32<float, 48, MTILE>(Af32.data(), k, B, Cf32.data(), n, k, kblock, cache,
+                                                           CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
+  }
+
+  template <int MTILE>
+  void ut_7bit_s8s8(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit4x2> b4(n * k / 2);
+    avector<bit2x4> b2(n * k / 4);
+    avector<bit1x8> b1(n * k / 8);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b4.data(), b4.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b2.data(), b2.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-64), int8_t(63));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<int8_t> A(MTILE * k);
+    fill_buffer_randn(A.data(), A.size(), int8_t(0), int8_t(127));
+    fill_buffer_randn(scalea.data(), scalea.size(), 0.01f, 0.02f);
+    for (int im = 0; im < MTILE; im++) {
+      for (int i = 0; i < k; i += 4) {
+        int bid = i / kblock + im * blks;
+        for (int j = 0; j < 4; j++) {
+          Af32[im * k + i + j] = (int(A[im * k + i + j])) * scalea[bid];
+        }
+      }
+    }
+
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s7_s8(b4.data(), b2.data(), b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 4) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 1) {
+        if (iasym) {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+        } else {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0])) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1])) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2])) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3])) * scaleb[bid * n + j];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{(uint8_t*)b4.data(),
+                               (uint8_t*)b2.data(),
+                               (uint8_t*)b1.data(),
+                               scaleb.data(),
+                               iasym ? bzp.data() : nullptr,
+                               7,
+                               n};
+    kernel::avx512f::vnni::gemv_7bit_s8s8_fp32<float, 48, MTILE>({(uint8_t*)A.data(), scalea.data(), nullptr, k, blks},
+                                                                 B, Cf32.data(), n, k, kblock, cache, CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
+  }
+
+  template <int MTILE>
+  void ut_7bit_u8s8(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit4x2> b4(n * k / 2);
+    avector<bit2x4> b2(n * k / 4);
+    avector<bit1x8> b1(n * k / 8);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b4.data(), b4.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b2.data(), b2.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-64), int8_t(63));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<uint8_t> A(MTILE * k), azp(MTILE * blks);
+    fill_buffer_randn(A.data(), A.size(), uint8_t(0), uint8_t(128));
+    fill_buffer_randn(azp.data(), azp.size(), uint8_t(50), uint8_t(64));
+    fill_buffer_randn(scalea.data(), scalea.size(), 0.01f, 0.02f);
+    for (int im = 0; im < MTILE; im++) {
+      for (int i = 0; i < k; i += 4) {
+        int bid = i / kblock + im * blks;
+        for (int j = 0; j < 4; j++) {
+          Af32[im * k + i + j] = (int(A[im * k + i + j]) - azp[bid]) * scalea[bid];
+        }
+      }
+    }
+
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s7_s8(b4.data(), b2.data(), b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 4) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 1) {
+        if (iasym) {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+        } else {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0])) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1])) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2])) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3])) * scaleb[bid * n + j];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{(uint8_t*)b4.data(),
+                               (uint8_t*)b2.data(),
+                               (uint8_t*)b1.data(),
+                               scaleb.data(),
+                               iasym ? bzp.data() : nullptr,
+                               7,
+                               n};
+    kernel::avx512f::vnni::gemv_7bit_u8s8_fp32<float, 48, MTILE>({A.data(), scalea.data(), azp.data(), k, blks}, B,
+                                                              Cf32.data(), n, k, kblock, cache, CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
   }
 
   template <int MTILE>
@@ -1268,8 +1449,8 @@ class UT_avx512_gemv {
   }
 };
 #ifdef BTLA_UT_KERNEL_INTRIN
-UT_avx512_gemv sUT_avx512_gemv;
 #endif
+UT_avx512_gemv sUT_avx512_gemv;
 #endif
 
 #if CompileAVX2()
@@ -1775,6 +1956,31 @@ class UT_avx2_gemv {
     ut_7bit_fp32<4>(24, 128, 32, true);
     ut_7bit_fp32<4>(24, 128, 32, false);
 
+    ut_6bit_fp32<1>(24, 128, 32, true);
+    ut_6bit_fp32<1>(24, 128, 32, false);
+    ut_6bit_fp32<4>(24, 128, 32, true);
+    ut_6bit_fp32<4>(24, 128, 32, false);
+
+    ut_5bit_fp32<1>(24, 128, 32, true);
+    ut_5bit_fp32<1>(24, 128, 32, false);
+    ut_5bit_fp32<4>(24, 128, 32, true);
+    ut_5bit_fp32<4>(24, 128, 32, false);
+
+    ut_4bit_fp32<1>(24, 128, 32, true);
+    ut_4bit_fp32<1>(24, 128, 32, false);
+    ut_4bit_fp32<4>(24, 128, 32, true);
+    ut_4bit_fp32<4>(24, 128, 32, false);
+
+    ut_3bit_fp32<1>(24, 128, 32, true);
+    ut_3bit_fp32<1>(24, 128, 32, false);
+    ut_3bit_fp32<4>(24, 128, 32, true);
+    ut_3bit_fp32<4>(24, 128, 32, false);
+
+    ut_2bit_fp32<1>(24, 128, 32, true);
+    ut_2bit_fp32<1>(24, 128, 32, false);
+    ut_2bit_fp32<4>(24, 128, 32, true);
+    ut_2bit_fp32<4>(24, 128, 32, false);
+
     CheckISA(AVX_VNNI);
     ut_7bit_u8s8<1>(24, 128, 32, true);
     ut_7bit_u8s8<1>(24, 128, 32, false);
@@ -1796,11 +2002,6 @@ class UT_avx2_gemv {
     ut_4bit_s8s8<4>(24, 128, 32, true);
     ut_4bit_s8s8<4>(24, 128, 32, false);
 
-    ut_4bit_fp32<1>(24, 128, 32, true);
-    ut_4bit_fp32<1>(24, 128, 32, false);
-    ut_4bit_fp32<4>(24, 128, 32, true);
-    ut_4bit_fp32<4>(24, 128, 32, false);
-
     ut_2bit<1>(24, 128, 32, true);
     ut_2bit<1>(24, 128, 32, false);
     ut_2bit<4>(24, 128, 32, true);
@@ -1810,16 +2011,6 @@ class UT_avx2_gemv {
     ut_2bit_s8s8<1>(24, 128, 32, false);
     ut_2bit_s8s8<4>(24, 128, 32, true);
     ut_2bit_s8s8<4>(24, 128, 32, false);
-
-    ut_2bit_fp32<1>(24, 128, 32, true);
-    ut_2bit_fp32<1>(24, 128, 32, false);
-    ut_2bit_fp32<4>(24, 128, 32, true);
-    ut_2bit_fp32<4>(24, 128, 32, false);
-
-    ut_3bit_fp32<1>(24, 128, 32, true);
-    ut_3bit_fp32<1>(24, 128, 32, false);
-    ut_3bit_fp32<4>(24, 128, 32, true);
-    ut_3bit_fp32<4>(24, 128, 32, false);
 
     ut_3bit_u8s8<1>(24, 128, 32, true);
     ut_3bit_u8s8<1>(24, 128, 32, false);
@@ -1831,11 +2022,6 @@ class UT_avx2_gemv {
     ut_3bit_s8s8<4>(24, 128, 32, true);
     ut_3bit_s8s8<4>(24, 128, 32, false);
 
-    ut_6bit_fp32<1>(24, 128, 32, true);
-    ut_6bit_fp32<1>(24, 128, 32, false);
-    ut_6bit_fp32<4>(24, 128, 32, true);
-    ut_6bit_fp32<4>(24, 128, 32, false);
-
     ut_6bit_u8s8<1>(24, 128, 32, true);
     ut_6bit_u8s8<1>(24, 128, 32, false);
     ut_6bit_u8s8<4>(24, 128, 32, true);
@@ -1845,11 +2031,6 @@ class UT_avx2_gemv {
     ut_6bit_s8s8<1>(24, 128, 32, false);
     ut_6bit_s8s8<4>(24, 128, 32, true);
     ut_6bit_s8s8<4>(24, 128, 32, false);
-
-    ut_5bit_fp32<1>(24, 128, 32, true);
-    ut_5bit_fp32<1>(24, 128, 32, false);
-    ut_5bit_fp32<4>(24, 128, 32, true);
-    ut_5bit_fp32<4>(24, 128, 32, false);
 
     ut_5bit_u8s8<1>(24, 128, 32, true);
     ut_5bit_u8s8<1>(24, 128, 32, false);
@@ -2710,8 +2891,8 @@ class UT_avx2_gemv {
   }
 };
 #ifdef BTLA_UT_KERNEL_INTRIN
-#endif
 UT_avx2_gemv sUT_avx2_gemv;
+#endif
 #endif
 
 }  // namespace ut

--- a/bestla/bestla/ut/kernel_intrin.cpp
+++ b/bestla/bestla/ut/kernel_intrin.cpp
@@ -275,6 +275,90 @@ class UT_avx512_decompress_s6_s8 {
 static UT_avx512_decompress_s6_s8 sUT_avx512_decompress_s6_s8;
 #endif
 
+class UT_avx512_decompress_s7_s8 {
+ public:
+  UT_avx512_decompress_s7_s8() {
+    UT_START();
+    CheckISA(AVX512F);
+    ut<1, 48>(32);
+    ut<4, 48>(32);
+    ut<1, 48>(32, true);
+    ut<2, 48>(32, true);
+    ut<4, 48>(32, true);
+  }
+
+  template <int PackRow, int NTILE>
+  void ut(int blocksize, bool isasym = false) {
+    int row = blocksize * 2;
+    int constexpr col = NTILE;
+    printf("Test Case %s: %d %d %d\n", __FUNCTION__, row, col, blocksize);
+    std::vector<utils::bit4x2> s4_wei(row * col / 2);
+    avector<utils::bit1x8> s1_wei(row * col / 8);
+    avector<utils::bit2x4> s2_wei(row * col / 4);
+
+    std::vector<int8_t> s8_wei(col * row);
+    std::vector<int8_t> s8_ref(col * row);
+    int blks = row / blocksize;
+    int row_offset = 8;
+    assert(blocksize % 8 == 0);
+    std::vector<int8_t> zp(col * blks);
+    fill_buffer_randn(zp.data(), zp.size(), int8_t(-64), int8_t(63));
+    std::vector<int8_t> rev(col * row);
+    fill_buffer_randn(s8_wei.data(), s8_wei.size(), int8_t(-64), int8_t(63));
+
+    for (int i = 0; i < col * row; i += 8) {
+      memcpy(&s8_ref[i], &s8_wei[i], 8 * sizeof(int8_t));
+      s4_wei[i / 2].x = (s8_wei[i + 0] + 64) & 0xf;
+      s4_wei[i / 2].y = (s8_wei[i + 1] + 64) & 0xf;
+      s4_wei[i / 2 + 1].x = (s8_wei[i + 2] + 64) & 0xf;
+      s4_wei[i / 2 + 1].y = (s8_wei[i + 3] + 64) & 0xf;
+      s4_wei[i / 2 + 2].x = (s8_wei[i + 4] + 64) & 0xf;
+      s4_wei[i / 2 + 2].y = (s8_wei[i + 5] + 64) & 0xf;
+      s4_wei[i / 2 + 3].x = (s8_wei[i + 6] + 64) & 0xf;
+      s4_wei[i / 2 + 3].y = (s8_wei[i + 7] + 64) & 0xf;
+
+      s2_wei[i / 4].a = ((s8_wei[i + 0] + 64) & 0x30) >> 4;
+      s2_wei[i / 4].b = ((s8_wei[i + 1] + 64) & 0x30) >> 4;
+      s2_wei[i / 4].c = ((s8_wei[i + 2] + 64) & 0x30) >> 4;
+      s2_wei[i / 4].d = ((s8_wei[i + 3] + 64) & 0x30) >> 4;
+      s2_wei[i / 4 + 1].a = ((s8_wei[i + 4] + 64) & 0x30) >> 4;
+      s2_wei[i / 4 + 1].b = ((s8_wei[i + 5] + 64) & 0x30) >> 4;
+      s2_wei[i / 4 + 1].c = ((s8_wei[i + 6] + 64) & 0x30) >> 4;
+      s2_wei[i / 4 + 1].d = ((s8_wei[i + 7] + 64) & 0x30) >> 4;
+
+      s1_wei[i / 8].a = ((s8_wei[i + 0] + 64) & 0x40) >> 6;
+      s1_wei[i / 8].b = ((s8_wei[i + 1] + 64) & 0x40) >> 6;
+      s1_wei[i / 8].c = ((s8_wei[i + 2] + 64) & 0x40) >> 6;
+      s1_wei[i / 8].d = ((s8_wei[i + 3] + 64) & 0x40) >> 6;
+      s1_wei[i / 8].e = ((s8_wei[i + 4] + 64) & 0x40) >> 6;
+      s1_wei[i / 8].f = ((s8_wei[i + 5] + 64) & 0x40) >> 6;
+      s1_wei[i / 8].g = ((s8_wei[i + 6] + 64) & 0x40) >> 6;
+      s1_wei[i / 8].h = ((s8_wei[i + 7] + 64) & 0x40) >> 6;
+    }
+    if (isasym) {
+      for (int i = 0; i < row; i += PackRow) {
+        for (int j = 0; j < NTILE; j++) {
+          for (int ip = 0; ip < PackRow; ip++) {
+            s8_ref[i * NTILE + j * PackRow + ip] -= zp[i / blocksize * NTILE + j];
+          }
+        }
+      }
+    }
+
+    kernel::avx512f::decompress_kblock_s7_s8<PackRow, NTILE>(s4_wei.data(), s2_wei.data(), s1_wei.data(),
+                                                             isasym ? zp.data() : nullptr, rev.data(), blocksize, NTILE,
+                                                             0, 0, row_offset, NTILE, cache, CacheSize);
+    kernel::avx512f::decompress_kblock_s7_s8<PackRow, NTILE>(
+        s4_wei.data() + row_offset * NTILE / 2, s2_wei.data() + row_offset * NTILE / 4,
+        s1_wei.data() + row_offset * NTILE / 8, isasym ? zp.data() : nullptr, rev.data() + row_offset * NTILE,
+        blocksize, NTILE, 0, row_offset, row - row_offset, NTILE, cache, CacheSize);
+    ut::buffer_error(s8_ref.data(), rev.data(), rev.size(), int8_t(0));
+  }
+};
+#ifdef BTLA_UT_KERNEL_INTRIN
+static UT_avx512_decompress_s7_s8 sUT_avx512_decompress_s7_s8;
+#endif
+
 class UT_avx512_decompress_s2_s8 {
  public:
   UT_avx512_decompress_s2_s8() {
@@ -1326,8 +1410,8 @@ class UT_avx2_decompress_s7_s8 {
     }
 
     kernel::avx2::decompress_kblock_s7_s8<PackRow, NTILE>(s4_wei.data(), s2_wei.data(), s1_wei.data(),
-                                                         isasym ? zp.data() : nullptr, rev.data(), blocksize, NTILE, 0,
-                                                         0, row_offset, NTILE, cache, CacheSize);
+                                                          isasym ? zp.data() : nullptr, rev.data(), blocksize, NTILE, 0,
+                                                          0, row_offset, NTILE, cache, CacheSize);
     kernel::avx2::decompress_kblock_s7_s8<PackRow, NTILE>(
         s4_wei.data() + row_offset * NTILE / 2, s2_wei.data() + row_offset * NTILE / 4,
         s1_wei.data() + row_offset * NTILE / 8, isasym ? zp.data() : nullptr, rev.data() + row_offset * NTILE,
@@ -1336,8 +1420,8 @@ class UT_avx2_decompress_s7_s8 {
   }
 };
 #ifdef BTLA_UT_KERNEL_INTRIN
-#endif
 static UT_avx2_decompress_s7_s8 sUT_avx2_decompress_s7_s8;
+#endif
 
 class UT_avx2_decompress_s5_s8 {
  public:
@@ -1685,7 +1769,23 @@ class UT_avx2_gemv {
  public:
   UT_avx2_gemv() {
     UT_START();
+    CheckISA(AVX2);
+    ut_7bit_fp32<1>(24, 128, 32, true);
+    ut_7bit_fp32<1>(24, 128, 32, false);
+    ut_7bit_fp32<4>(24, 128, 32, true);
+    ut_7bit_fp32<4>(24, 128, 32, false);
+
     CheckISA(AVX_VNNI);
+    ut_7bit_u8s8<1>(24, 128, 32, true);
+    ut_7bit_u8s8<1>(24, 128, 32, false);
+    ut_7bit_u8s8<4>(24, 128, 32, true);
+    ut_7bit_u8s8<4>(24, 128, 32, false);
+
+    ut_7bit_s8s8<1>(24, 128, 32, true);
+    ut_7bit_s8s8<1>(24, 128, 32, false);
+    ut_7bit_s8s8<4>(24, 128, 32, true);
+    ut_7bit_s8s8<4>(24, 128, 32, false);
+
     ut_4bit<1>(24, 128, 32, true);
     ut_4bit<1>(24, 128, 32, false);
     ut_4bit<4>(24, 128, 32, false);
@@ -2445,10 +2545,173 @@ class UT_avx2_gemv {
                                                               Cf32.data(), n, k, kblock, cache, CacheSize);
     buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
   }
+
+  template <int MTILE>
+  void ut_7bit_fp32(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit4x2> b4(n * k / 2);
+    avector<bit1x8> b1(n * k / 8);
+    avector<bit2x4> b2(n * k / 4);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b4.data(), b4.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b2.data(), b2.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(Af32.data(), Af32.size(), -0.5f, 0.5f);
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-64), int8_t(63));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s7_s8(b4.data(), b2.data(), b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 1) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 4) {
+        if (iasym) {
+          Bf32[(i)*n + j + 0] = (b8[(i)*n + j + 0] - bzp[bid * n + j + 0]) * scaleb[bid * n + j + 0];
+          Bf32[(i)*n + j + 1] = (b8[(i)*n + j + 1] - bzp[bid * n + j + 1]) * scaleb[bid * n + j + 1];
+          Bf32[(i)*n + j + 2] = (b8[(i)*n + j + 2] - bzp[bid * n + j + 2]) * scaleb[bid * n + j + 2];
+          Bf32[(i)*n + j + 3] = (b8[(i)*n + j + 3] - bzp[bid * n + j + 3]) * scaleb[bid * n + j + 3];
+        } else {
+          Bf32[(i)*n + j + 0] = (b8[(i)*n + j + 0]) * scaleb[bid * n + j + 0];
+          Bf32[(i)*n + j + 1] = (b8[(i)*n + j + 1]) * scaleb[bid * n + j + 1];
+          Bf32[(i)*n + j + 2] = (b8[(i)*n + j + 2]) * scaleb[bid * n + j + 2];
+          Bf32[(i)*n + j + 3] = (b8[(i)*n + j + 3]) * scaleb[bid * n + j + 3];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{(uint8_t*)b4.data(),
+                               (uint8_t*)b2.data(),
+                               (uint8_t*)b1.data(),
+                               scaleb.data(),
+                               iasym ? bzp.data() : nullptr,
+                               7,
+                               n};
+    kernel::avx2::gemv_7bit_fp32_fp32<float, 24, MTILE>(Af32.data(), k, B, Cf32.data(), n, k, kblock, cache, CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
+  }
+
+  template <int MTILE>
+  void ut_7bit_u8s8(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit4x2> b4(n * k / 2);
+    avector<bit2x4> b2(n * k / 4);
+    avector<bit1x8> b1(n * k / 8);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b4.data(), b4.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b2.data(), b2.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-64), int8_t(63));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<uint8_t> A(MTILE * k), azp(MTILE * blks);
+    fill_buffer_randn(A.data(), A.size(), uint8_t(0), uint8_t(128));
+    fill_buffer_randn(azp.data(), azp.size(), uint8_t(50), uint8_t(64));
+    fill_buffer_randn(scalea.data(), scalea.size(), 0.01f, 0.02f);
+    for (int im = 0; im < MTILE; im++) {
+      for (int i = 0; i < k; i += 4) {
+        int bid = i / kblock + im * blks;
+        for (int j = 0; j < 4; j++) {
+          Af32[im * k + i + j] = (int(A[im * k + i + j]) - azp[bid]) * scalea[bid];
+        }
+      }
+    }
+
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s7_s8(b4.data(), b2.data(), b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 4) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 1) {
+        if (iasym) {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+        } else {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0])) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1])) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2])) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3])) * scaleb[bid * n + j];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{(uint8_t*)b4.data(),
+                               (uint8_t*)b2.data(),
+                               (uint8_t*)b1.data(),
+                               scaleb.data(),
+                               iasym ? bzp.data() : nullptr,
+                               7,
+                               n};
+    kernel::avx2::vnni::gemv_7bit_u8s8_fp32<float, 24, MTILE>({A.data(), scalea.data(), azp.data(), k, blks}, B,
+                                                              Cf32.data(), n, k, kblock, cache, CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
+  }
+
+  template <int MTILE>
+  void ut_7bit_s8s8(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit4x2> b4(n * k / 2);
+    avector<bit2x4> b2(n * k / 4);
+    avector<bit1x8> b1(n * k / 8);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b4.data(), b4.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b2.data(), b2.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-64), int8_t(63));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<int8_t> A(MTILE * k);
+    fill_buffer_randn(A.data(), A.size(), int8_t(0), int8_t(127));
+    fill_buffer_randn(scalea.data(), scalea.size(), 0.01f, 0.02f);
+    for (int im = 0; im < MTILE; im++) {
+      for (int i = 0; i < k; i += 4) {
+        int bid = i / kblock + im * blks;
+        for (int j = 0; j < 4; j++) {
+          Af32[im * k + i + j] = (int(A[im * k + i + j])) * scalea[bid];
+        }
+      }
+    }
+
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s7_s8(b4.data(), b2.data(), b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 4) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 1) {
+        if (iasym) {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+        } else {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0])) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1])) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2])) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3])) * scaleb[bid * n + j];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{(uint8_t*)b4.data(),
+                               (uint8_t*)b2.data(),
+                               (uint8_t*)b1.data(),
+                               scaleb.data(),
+                               iasym ? bzp.data() : nullptr,
+                               7,
+                               n};
+    kernel::avx2::vnni::gemv_7bit_s8s8_fp32<float, 24, MTILE>({(uint8_t*)A.data(), scalea.data(), azp.data(), k, blks},
+                                                              B, Cf32.data(), n, k, kblock, cache, CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
+  }
 };
 #ifdef BTLA_UT_KERNEL_INTRIN
-UT_avx2_gemv sUT_avx2_gemv;
 #endif
+UT_avx2_gemv sUT_avx2_gemv;
 #endif
 
 }  // namespace ut

--- a/bestla/bestla/ut/kernel_intrin.cpp
+++ b/bestla/bestla/ut/kernel_intrin.cpp
@@ -2704,8 +2704,8 @@ class UT_avx2_gemv {
                                iasym ? bzp.data() : nullptr,
                                7,
                                n};
-    kernel::avx2::vnni::gemv_7bit_s8s8_fp32<float, 24, MTILE>({(uint8_t*)A.data(), scalea.data(), azp.data(), k, blks},
-                                                              B, Cf32.data(), n, k, kblock, cache, CacheSize);
+    kernel::avx2::vnni::gemv_7bit_s8s8_fp32<float, 24, MTILE>({(uint8_t*)A.data(), scalea.data(), nullptr, k, blks}, B,
+                                                              Cf32.data(), n, k, kblock, cache, CacheSize);
     buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
   }
 };

--- a/bestla/bestla/ut/kernel_intrin.cpp
+++ b/bestla/bestla/ut/kernel_intrin.cpp
@@ -592,7 +592,6 @@ class UT_avx512_gemv {
     ut_7bit_u8s8<1>(48, 128, 32, false);
     ut_7bit_u8s8<4>(48, 128, 32, true);
     ut_7bit_u8s8<4>(48, 128, 32, false);
-
   }
 
   template <int MTILE>
@@ -755,7 +754,7 @@ class UT_avx512_gemv {
                                7,
                                n};
     kernel::avx512f::vnni::gemv_7bit_u8s8_fp32<float, 48, MTILE>({A.data(), scalea.data(), azp.data(), k, blks}, B,
-                                                              Cf32.data(), n, k, kblock, cache, CacheSize);
+                                                                 Cf32.data(), n, k, kblock, cache, CacheSize);
     buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
   }
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -6,7 +6,7 @@ Argument description of run.py ([supported MatMul combinations](#supported-matri
 | Argument                    | Description                                                                                                   |
 | --------------              | ---------------------------------------------------------------------                                         |
 | model                       | Directory containing model file or model id: String                                                           |
-| --weight_dtype              | Data type of quantized weight: int4/int3/int2/int5/int6/int8/fp8(=fp8_e4m3)/fp8_e5m2/fp4(=fp4e2m1)/nf4 (default int4)                                                       |
+| --weight_dtype              | Data type of quantized weight: int4/int3/int2/int5/int6/int7/int8/fp8(=fp8_e4m3)/fp8_e5m2/fp4(=fp4e2m1)/nf4 (default int4)                                                       |
 | --alg                       | Quantization algorithm: sym/asym (default sym)                                                                |
 | --group_size                | Group size: Int, 16/32/64/128/-1 (per channel) (default: 32)                                                                                 |
 | --scale_dtype               | Data type of scales: fp32/bf16/fp8 (default fp32)                                                                 |
@@ -60,7 +60,7 @@ Argument description of quantize.py ([supported MatMul combinations](#supported-
 | --build_dir     | Path to the build file: String                               |
 | --config        | Path to the configuration file: String (default: "")         |
 | --nthread       | Number of threads to use: Int (default: 1)                   |
-| --weight_dtype  | Data type of quantized weight: int4/int3/int2/int5/int6/int8/fp8(=fp8_e4m3)/fp8_e5m2/fp4(=fp4_e2m1)/nf4 (default: int4)     |
+| --weight_dtype  | Data type of quantized weight: int4/int3/int2/int5/int6/int7/int8/fp8(=fp8_e4m3)/fp8_e5m2/fp4(=fp4_e2m1)/nf4 (default: int4)     |
 | --alg           | Quantization algorithm to use: sym/asym (default: sym)       |
 | --group_size    | Group size: Int 16/32/64/128/-1 (per channel) (default: 32)                                |
 | --scale_dtype   | Data type of scales: bf16/fp32/fp8 (default: fp32)               |
@@ -69,7 +69,7 @@ Argument description of quantize.py ([supported MatMul combinations](#supported-
 
 #### Supported Matrix Multiplication Data Types Combinations
 
-Our Neural Speed supports  INT4 / INT3 / INT2 / INT5 / INT6 / INT8 / FP8 (E4M3, E5M2) / FP4 (E2M1) / NF4 weight-only quantization and FP32 / FP16 / BF16 / INT8 computation forward matmul on the Intel platforms. Here are the all supported data types combinations for matmul operations (quantization and forward).
+Our Neural Speed supports  INT4 / INT3 / INT2 / INT5 / INT6 / INT7 / INT8 / FP8 (E4M3, E5M2) / FP4 (E2M1) / NF4 weight-only quantization and FP32 / FP16 / BF16 / INT8 computation forward matmul on the Intel platforms. Here are the all supported data types combinations for matmul operations (quantization and forward).
 > This table will be updated frequently due to active development. For details you can refer to [BesTLA](../bestla#weight-only)
 
 | Weight dtype | Compute dtype (default value) | Scale dtype (default value) | Quantization scheme (default value) |
@@ -81,6 +81,7 @@ Our Neural Speed supports  INT4 / INT3 / INT2 / INT5 / INT6 / INT8 / FP8 (E4M3, 
 | INT2 | INT8 / BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym / asym (sym) |
 | INT5 | INT8 / BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym / asym (sym) |
 | INT6 | INT8 / BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym / asym (sym) |
+| INT7 | INT8 / BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym / asym (sym) |
 | FP8 (E4M3, E5M2) | BF16 / FP16 / FP32 (FP32) | FP8 (FP8) | sym (sym) |
 | FP4 (E2M1) | BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym (sym) |
 | NF4 | BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym (sym) |

--- a/neural_speed/core/README.md
+++ b/neural_speed/core/README.md
@@ -26,15 +26,17 @@ int3 | symmetric or asymmetric | multiplier of 8, -1<sup>1</sup>
 int2 | symmetric or asymmetric | multiplier of 8, -1<sup>1</sup>
 int5 | symmetric or asymmetric | multiplier of 8, -1<sup>1</sup>
 int6 | symmetric or asymmetric | multiplier of 8, -1<sup>1</sup>
+int7 | symmetric or asymmetric<sup>2</sup> | multiplier of 8, -1<sup>1</sup>
 int8 | symmetric | multiplier of 8, -1<sup>1</sup>
 fp4 | | multiplier of 8
 nf4 | | multiplier of 8
 
 <sup>1</sup>: group size=-1 means per channel quantization on output channel (or group size equals to input channel size).
+<sup>2</sup>: int7 + asymmetric may cause numeric overflow if the device only has AVX2 without AVX_VNNI.
 
 NOTE:
 1. AMX_INT8 requires group size is aligend to 128 (best hardware efficiency)
-2. int3 and int2 require algo=asymmetric, the accuracy of algo=symmetric is very poor
+2. int3 and int2 have accuracy loss.
 
 ### Hybrid quantization support
 We can support the hybrid quantization combination. E.g. int4 x int2 mixed quantization.   
@@ -56,7 +58,7 @@ We support three kinds of kernel fusion for transformer models: QKV, MHA (multi-
         <tr>
             <td>QKV</td>
             <td >GPT-J<br>LLaMA</td>
-            <td>AMX_INT8, AVX512_VNNI, AVX_VNNI</td>
+            <td>AMX_INT8, AVX512_VNNI, AVX512F, AMX_BF16, AVX_VNNI, AVX2</td>
         </tr>
         <tr>
             <td>FFN</td>
@@ -84,5 +86,5 @@ Older architecture (before 12th Gen)|  sym int3<br>group size=128<br>compute typ
 
 NOTE:  
 1. group_size=-1 requires the INC's finetuned model, or it may have lower accuracy than small group sizes. It has the smallest model size, and the fastest first-token performance.
-2. group_size=128 is a balance of accuracy and speed if you want RTN quantization only.  
+2. group_size=128 is a balance of accuracy and speed if you want RTN quantization only.
 3. group_size=32, scale_dtype=bf16, compute_dtype=int8, alg=sym equals llama.cpp's Q4_0.

--- a/neural_speed/models/model_utils/quant_utils.cpp
+++ b/neural_speed/models/model_utils/quant_utils.cpp
@@ -339,7 +339,7 @@ size_t bestla_quantize(const float* f32ptr, void* dstpr, const quant_params_inte
     }
     scale_type = BTLA_DTYPE::F8_E8M0;
   }
-  if (quant_type == BTLA_DTYPE::S1_CLIP || quant_type == BTLA_DTYPE::S7_CLIP) {
+  if (quant_type == BTLA_DTYPE::S1_CLIP) {
     printf("Current not support this data type, reset to int4\n");
     quant_type = BTLA_DTYPE::S4_CLIP;
   }


### PR DESCRIPTION
## Type of Change

new weight_dtype: int7

LLaMa2-7B
weight_dtype=int7, group_size=128, alg=sym, scale_dtype=bf16, comp_dtype=int8:
```
 Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. But her parents were very worried about her safety, so they refused to
model_print_timings:        load time =   409.37 ms
model_print_timings:      sample time =     3.48 ms /    16 runs   (    0.22 ms per token)
model_print_timings: prompt eval time =   216.56 ms /    33 tokens (    6.56 ms per token)
model_print_timings:        eval time =  1331.87 ms /    15 runs   (   88.79 ms per token)
model_print_timings:       total time =  1751.09 ms
========== eval time log of each prediction ==========
prediction   0, time: 216.56ms
prediction   1, time: 88.50ms
prediction   2, time: 88.45ms
prediction   3, time: 88.42ms
prediction   4, time: 88.42ms
```
|    Tasks     |Version|Filter|n-shot|  Metric  |Value |   |Stderr|
|--------------|------:|------|-----:|----------|-----:|---|-----:|
|winogrande    |      1|none  |     0|acc       |0.6811|±  |0.0131|
|piqa          |      1|none  |     0|acc       |0.7633|±  |0.0099|
|              |       |none  |     0|acc_norm  |0.7715|±  |0.0098|
|lambada_openai|      1|none  |     0|perplexity|3.3564|±  |0.0899|
|              |       |none  |     0|acc       |0.6998|±  |0.0064|

weight_dtype=int7, group_size=128, alg=asym, scale_dtype=bf16, comp_dtype=int8:
 ```
Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun while doing it. As she grew older, her parents started taking her on vac
model_print_timings:        load time =   231.56 ms
model_print_timings:      sample time =     4.39 ms /    16 runs   (    0.27 ms per token)
model_print_timings: prompt eval time =   216.78 ms /    33 tokens (    6.57 ms per token)
model_print_timings:        eval time =  1346.89 ms /    15 runs   (   89.79 ms per token)
model_print_timings:       total time =  1601.25 ms
========== eval time log of each prediction ==========
prediction   0, time: 216.78ms
prediction   1, time: 89.52ms
prediction   2, time: 89.39ms
prediction   3, time: 89.19ms
prediction   4, time: 89.35ms
```
|    Tasks     |Version|Filter|n-shot|  Metric  |Value |   |Stderr|
|--------------|------:|------|-----:|----------|-----:|---|-----:|
|winogrande    |      1|none  |     0|acc       |0.6811|±  |0.0131|
|piqa          |      1|none  |     0|acc       |0.7633|±  |0.0099|
|              |       |none  |     0|acc_norm  |0.7688|±  |0.0098|
|lambada_openai|      1|none  |     0|perplexity|3.3594|±  |0.0899|
|              |       |none  |     0|acc       |0.6988|±  |0.0064|

**int7/int4**=1.74