### PR TITLE
[BesTLA] Support Int1 for kernels and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Neural Speed is an innovative library designed to support the efficient inference of large language models (LLMs) on Intel platforms through the state-of-the-art (SOTA) low-bit quantization powered by [Intel Neural Compressor](https://github.com/intel/neural-compressor). The work is inspired by [llama.cpp](https://github.com/ggerganov/llama.cpp) and further optimized for Intel platforms with our innovations in [NeurIPS' 2023](https://arxiv.org/abs/2311.00502)
 
 ## Key Features
-- Highly optimized low-precision kernels on CPUs with ISAs (AMX, VNNI, AVX512F, AVX_VNNI and AVX2). See [details](neural_speed/core/README.md)
+- Highly optimized kernels on CPUs with ISAs (AMX, VNNI, AVX512F, AVX_VNNI and AVX2) for N-bit weight (int1, int2, int3, int4, int5, int6, int7 and int8). See [details](neural_speed/core/README.md)
 - Up to 40x performance speedup on popular LLMs compared with llama.cpp. See [details](https://medium.com/@NeuralCompressor/llm-performance-of-intel-extension-for-transformers-f7d061556176) 
 - Tensor parallelism across sockets/nodes on CPUs. See [details](./docs/tensor_parallelism.md)
 

--- a/bestla/README.md
+++ b/bestla/README.md
@@ -28,6 +28,7 @@ BesTLA provides weight-only linear computational capabilities for LLM inference.
 | INT5                   | INT8 / BF16 / FP32 |    BF16 / FP32    | sym / asym |
 | INT6                   | INT8 / BF16 / FP32 |    BF16 / FP32    | sym / asym |
 | INT7                   | INT8 / BF16 / FP32 |    BF16 / FP32    | sym / asym |
+| INT1                   | INT8 / BF16 / FP32 |    BF16 / FP32    | sym / asym |
 | FP8 (E4M3, E5M2)       |    BF16 / FP32     | FP32 / FP8 (E8M0) |    sym     |
 | FP4 (E2M1)             |    BF16 / FP32     |    BF16 / FP32    |    sym     |
 | NF4                    |    BF16 / FP32     |    BF16 / FP32    |    sym     |
@@ -49,6 +50,11 @@ BesTLA provides assembly-level postop-fusion through epilogue to minimize the ov
 - RELU
 - EXP
 - TANH
+
+## Optimized thread pool for hybrid CPUs
+Our thread pool is optimized for hybrid CPUs (client CPUs after Core 11th). It will be much faster than OMP thread pool.
+Recommend to use all threads and cores on hybrid CPU: P cores * 2 + E cores.
+
 ## Compilation Requirements and Usage
 Compile: 
 
@@ -67,7 +73,7 @@ Best Performance:
 Usage:
 ```cmake
 add_subdirectory(bestla)
-target_link_libraries("${YOUR_PROJECT}" bestla::bestla)
+target_link_libraries("${YOUR_PROJECT}" neural_speed::bestla)
 ```
 
 # Benchmark

--- a/bestla/bestla/kernel_avx2.h
+++ b/bestla/bestla/kernel_avx2.h
@@ -550,7 +550,7 @@ static inline BTLA_CODE decompress_kblock_s4_s8(utils::int4x2* srcptr, int8_t* z
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::int4x2 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -764,7 +764,7 @@ static inline BTLA_CODE decompress_kblock_s2_s8(utils::bit2x4* bit2ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -1022,7 +1022,7 @@ static inline BTLA_CODE decompress_kblock_s3_s8(utils::bit2x4* bit2ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -1056,6 +1056,230 @@ static inline BTLA_CODE decompress_kblock_s3_s8(utils::bit2x4* bit2ptr, utils::b
   } else {
     size_t elesize = static_cast<size_t>(row) * col;
     return decompress_s3_s8(bit2ptr, bit1ptr, dstptr, elesize, tmp, tmpsize);
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int NTILE>
+static inline BTLA_CODE decompress_kblock_s1_s8_pack4_row(utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+                                                          int blocksize, int ldzp, int n_offset, int k_offset, int row,
+                                                          int8_t* tmp, size_t tmpsize) {
+  int constexpr NReg = NTILE / 8;
+  static_assert((NTILE % 8) == 0);
+  int constexpr PackRow = 4;
+  __m256i v_zp_y[NReg];
+  const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0);
+  int constexpr FullRange = 1 << (1 - 1);
+  auto vbias = _mm256_set1_epi8(FullRange);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+  for (int ir = 0; ir < row; ir += blocksize) {
+    auto zptr = zpptr + (k_offset + ir) / blocksize * ldzp + n_offset;
+    for (int i = 0; i < NReg; i++) {
+      v_zp_y[i] = load_zp_epi8_broadcast_epi32(zptr + i * 8, vindex);
+      v_zp_y[i] = _mm256_add_epi8(v_zp_y[i], vbias);
+    }
+    int k_remain = utils::remainsize(ir, row, blocksize);
+    for (int ib = 0; ib < k_remain; ib += PackRow) {
+      auto b1ptr = bit1ptr + (ir + ib) * NTILE / 8;
+      for (int i = 0; i < NReg; i++) {
+        auto vb1 = unpack_1bits(b1ptr + i * 4, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+        vb1 = _mm256_srli_epi32(vb1, 2);
+        vb1 = _mm256_sub_epi8(vb1, v_zp_y[i]);
+        _mm256_storeu_si256((__m256i*)(dstptr + i * 32 + (ir + ib) * NTILE), vb1);
+      }
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int NTILE>
+static inline BTLA_CODE decompress_kblock_s1_s8_pack2_row(utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+                                                          int blocksize, int ldzp, int n_offset, int k_offset, int row,
+                                                          int8_t* tmp, size_t tmpsize) {
+  int constexpr NReg = NTILE / 8;
+  static_assert((NTILE % 8) == 0);
+  int constexpr PackRow = 2;
+  int constexpr Unroll = 2;
+  __m256i v_zp_y[NReg];
+  const auto vindex = _mm256_set_epi8(14, 14, 12, 12, 10, 10, 8, 8, 6, 6, 4, 4, 2, 2, 0, 0, 14, 14, 12, 12, 10, 10, 8,
+                                      8, 6, 6, 4, 4, 2, 2, 0, 0);
+  int constexpr FullRange = 1 << (1 - 1);
+  auto vbias = _mm256_set1_epi8(FullRange);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+
+  for (int ir = 0; ir < row; ir += blocksize) {
+    auto zptr = zpptr + (k_offset + ir) / blocksize * ldzp + n_offset;
+    memcpy(tmp, zptr, NTILE * sizeof(int8_t));
+    memcpy(tmp + NTILE, zptr, NTILE * sizeof(int8_t));
+    for (int i = 0; i < NReg; i++) {
+      v_zp_y[i] = load_zp_epi8_broadcast_epi16_v16(tmp + i * 16, vindex);
+      v_zp_y[i] = _mm256_add_epi8(v_zp_y[i], vbias);
+    }
+    int k_remain = utils::remainsize(ir, row, blocksize);
+    int k_remain_unrll = utils::padto_le(k_remain, PackRow * Unroll);
+    int ib = 0;
+    for (; ib < k_remain_unrll; ib += PackRow * Unroll) {
+      auto b1ptr = bit1ptr + (ir + ib) * NTILE / 8;
+      for (int i = 0; i < NReg; i++) {
+        auto vb1 = unpack_1bits(b1ptr + i * 4, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+        vb1 = _mm256_srli_epi32(vb1, 2);
+        vb1 = _mm256_sub_epi8(vb1, v_zp_y[i]);
+        _mm256_storeu_si256((__m256i*)(dstptr + i * 32 + (ir + ib) * NTILE), vb1);
+      }
+    }
+    int k_tail = k_remain - k_remain_unrll;
+    if (k_tail > 0) {
+      auto tmpb1ptr = tmp;
+      memcpy(tmpb1ptr, bit1ptr + (ir + ib) * NTILE / 8, k_tail * NTILE / 8);
+      auto tmpout = tmp + Unroll * NTILE;
+      for (int i = 0; i < NReg; i++) {
+        auto vb1 = unpack_1bits((utils::bit1x8*)(tmpb1ptr + i * 4), bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+        vb1 = _mm256_srli_epi32(vb1, 2);
+        vb1 = _mm256_sub_epi8(vb1, v_zp_y[i]);
+        _mm256_storeu_si256((__m256i*)(tmpout + i * 32), vb1);
+      }
+      memcpy(dstptr + (ir + ib) * NTILE, tmpout, k_tail * NTILE);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int NTILE>
+static inline BTLA_CODE decompress_kblock_s1_s8_pack1_row(utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+                                                          int blocksize, int ldzp, int n_offset, int k_offset, int row,
+                                                          int8_t* tmp, size_t tmpsize) {
+  int constexpr NReg = NTILE / 8;
+  static_assert((NTILE % 8) == 0);
+  int constexpr PackRow = 1;
+  int constexpr Unroll = 4;
+  int constexpr UnpackLoop = Unroll * NTILE / 32;
+  int constexpr FullRange = 1 << (1 - 1);
+  auto vbias = _mm256_set1_epi8(FullRange);
+  __m256i v_zp_y[UnpackLoop];
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+  for (int ir = 0; ir < row; ir += blocksize) {
+    auto zptr = zpptr + (k_offset + ir) / blocksize * ldzp + n_offset;
+    for (int i = 0; i < Unroll; i++) {
+      memcpy(tmp + i * NTILE, zptr, NTILE * sizeof(int8_t));
+    }
+    for (int i = 0; i < UnpackLoop; i++) {
+      v_zp_y[i] = _mm256_loadu_si256((const __m256i*)(tmp + i * 32));
+      v_zp_y[i] = _mm256_add_epi8(v_zp_y[i], vbias);
+    }
+    int k_remain = utils::remainsize(ir, row, blocksize);
+    int k_remain_unrll = utils::padto_le(k_remain, Unroll);
+    int ib = 0;
+    for (; ib < k_remain_unrll; ib += Unroll) {
+      auto b1ptr = bit1ptr + (ir + ib) * NTILE / 8;
+      for (int i = 0; i < UnpackLoop; i++) {
+        auto vb1 = unpack_1bits(b1ptr + i * 4, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+        vb1 = _mm256_srli_epi32(vb1, 2);
+        vb1 = _mm256_sub_epi8(vb1, v_zp_y[i]);
+        _mm256_storeu_si256((__m256i*)(dstptr + i * 32 + (ir + ib) * NTILE), vb1);
+      }
+    }
+
+    int k_tail = k_remain - k_remain_unrll;
+    if (k_tail > 0) {
+      auto tmpb1ptr = tmp;
+      memcpy(tmpb1ptr, bit1ptr + (ir + ib) * NTILE / 8, k_tail * NTILE / 8);
+      auto tmpout = tmp + Unroll * NTILE;
+      for (int i = 0; i < UnpackLoop; i++) {
+        auto vb1 = unpack_1bits((utils::bit1x8*)(tmpb1ptr + i * 4), bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+        vb1 = _mm256_srli_epi32(vb1, 2);
+        vb1 = _mm256_sub_epi8(vb1, v_zp_y[i]);
+        _mm256_storeu_si256((__m256i*)(tmpout + i * 32), vb1);
+      }
+      memcpy(dstptr + (ir + ib) * NTILE, tmpout, k_tail * NTILE);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+static inline BTLA_CODE decompress_s1_s8(utils::bit1x8* bit1ptr, int8_t* dstptr, size_t unpack_elt, int8_t* tmp,
+                                         size_t tmpsize) {
+  int constexpr VBits = 256;
+  int constexpr VElt = VBits / 8;
+  int i = 0;
+  int constexpr FullRange = 1 << (1 - 1);
+  auto vbias = _mm256_set1_epi8(FullRange);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+  int elt_pad = utils::padto_le(unpack_elt, VElt);
+  for (; i < elt_pad; i += VElt) {
+    auto vb1 = unpack_1bits(bit1ptr + i / 8, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+    vb1 = _mm256_srli_epi32(vb1, 2);
+    vb1 = _mm256_sub_epi8(vb1, vbias);
+    _mm256_storeu_si256((__m256i*)(dstptr + i), vb1);
+  }
+  if (elt_pad < unpack_elt) {
+    if (unpack_elt >= 32) {
+      i = unpack_elt - 32;
+      auto vb1 = unpack_1bits(bit1ptr + i / 8, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+      vb1 = _mm256_srli_epi32(vb1, 2);
+      vb1 = _mm256_sub_epi8(vb1, vbias);
+      _mm256_storeu_si256((__m256i*)(dstptr + i), vb1);
+    } else {
+      ref::decompress_s1_s8(bit1ptr + i / 8, dstptr + i, unpack_elt - i, tmp, tmpsize);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <int PackRow, int NTILE>
+static inline BTLA_CODE decompress_kblock_s1_s8(utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr, int blocksize,
+                                                int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
+                                                size_t tmpsize) {
+  if (zpptr) {
+    typedef BTLA_CODE (*decompfunc)(utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+                                    int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
+    decompfunc func = nullptr;
+    if (col == NTILE) {
+      if constexpr (PackRow == 1) {
+        func = &decompress_kblock_s1_s8_pack1_row<NTILE>;
+      }
+      if constexpr (PackRow == 2) {
+        func = &decompress_kblock_s1_s8_pack2_row<NTILE>;
+      }
+      if constexpr (PackRow == 4) {
+        func = &decompress_kblock_s1_s8_pack4_row<NTILE>;
+      }
+      if (func) {
+        int head_end = utils::padto(k_offset, blocksize);
+        head_end = std::min(head_end, k_offset + row);
+        int head_size = head_end - k_offset;
+        if (head_size > 0) {
+          (*func)(bit1ptr, zpptr, dstptr, blocksize, ldzp, n_offset, k_offset, head_size, tmp, tmpsize);
+        }
+        int body_size = row - head_size;
+        if (body_size > 0) {
+          (*func)(bit1ptr + head_size * NTILE / 8, zpptr, dstptr + head_size * NTILE, blocksize, ldzp, n_offset,
+                  head_end, body_size, tmp, tmpsize);
+        }
+        return BTLA_CODE::Success;
+      }
+    }
+    assert(0);
+    return BTLA_CODE::NotSupport;
+  } else {
+    size_t elesize = static_cast<size_t>(row) * col;
+    return decompress_s1_s8(bit1ptr, dstptr, elesize, tmp, tmpsize);
   }
   return BTLA_CODE::Success;
 }
@@ -1276,7 +1500,7 @@ static inline BTLA_CODE decompress_kblock_s5_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -1590,9 +1814,9 @@ static inline BTLA_CODE decompress_kblock_s7_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset,
                                                 int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr,
-                                    int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp, int n_offset,
-                                    int k_offset, int row, int8_t* tmp, size_t tmpsize);
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
+                                    int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
+                                    int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
       if constexpr (PackRow == 1) {
@@ -1853,7 +2077,7 @@ static inline BTLA_CODE decompress_kblock_s6_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -2623,6 +2847,46 @@ inline BTLA_CODE decompress_kblock_s3_fp(utils::bit2x4* b2ptr, utils::bit1x8* b1
       decompress_kblock_s3_fp_row<PackRow, NTILE, DST_T>(
           b2ptr + head_size * NTILE / 4, b1ptr + head_size * NTILE / 8, dstptr + head_size * NTILE, body_size, scales_,
           sdtype, zero_points, head_end, n_offset, blocksize, ldzp, tmp, tmpsize);
+    }
+    return BTLA_CODE::Success;
+  }
+  return ret;
+}
+
+template <int PackRow, int NTILE, typename DST_T>
+inline BTLA_CODE decompress_kblock_s1_fp_row(utils::bit1x8* b1ptr, DST_T* dstptr, int row, void* scales_,
+                                             BTLA_DTYPE sdtype, int8_t* zero_points, int k_offset, int n_offset,
+                                             int blocksize, int ldzp, int8_t* tmp, size_t tmpsize) {
+  int constexpr NReg = NTILE / 8;
+  const auto DstSize = row * NTILE * sizeof(DST_T);
+  const auto S8Size = row * NTILE * sizeof(int8_t);
+  auto tmps8ptr = (int8_t*)dstptr;
+  tmps8ptr += DstSize - S8Size;
+  auto ret = decompress_kblock_s1_s8<PackRow, NTILE>(b1ptr, zero_points, tmps8ptr, blocksize, ldzp, n_offset, k_offset,
+                                                     row, NTILE, tmp, tmpsize);
+  assert(ret == BTLA_CODE::Success);
+  return decompress_kblock_s8_fp_row<PackRow, NTILE, DST_T>(tmps8ptr, dstptr, row, scales_, sdtype, nullptr, k_offset,
+                                                            n_offset, blocksize, ldzp, tmp, tmpsize);
+}
+
+template <int PackRow, int NTILE, typename DST_T>
+inline BTLA_CODE decompress_kblock_s1_fp(utils::bit1x8* b1ptr, DST_T* dstptr, int row, int col, void* scales_,
+                                         BTLA_DTYPE sdtype, int8_t* zero_points, int k_offset, int n_offset,
+                                         int blocksize, int ldzp, int8_t* tmp, size_t tmpsize) {
+  auto ret = BTLA_CODE::NotSupport;
+  if (col == NTILE) {
+    int head_end = utils::padto(k_offset, blocksize);
+    head_end = std::min(head_end, k_offset + row);
+    int head_size = head_end - k_offset;
+    if (head_size > 0) {
+      decompress_kblock_s1_fp_row<PackRow, NTILE, DST_T>(b1ptr, dstptr, head_size, scales_, sdtype, zero_points,
+                                                         k_offset, n_offset, blocksize, ldzp, tmp, tmpsize);
+    }
+    int body_size = row - head_size;
+    if (body_size > 0) {
+      decompress_kblock_s1_fp_row<PackRow, NTILE, DST_T>(b1ptr + head_size * NTILE / 8, dstptr + head_size * NTILE,
+                                                         body_size, scales_, sdtype, zero_points, head_end, n_offset,
+                                                         blocksize, ldzp, tmp, tmpsize);
     }
     return BTLA_CODE::Success;
   }
@@ -3490,12 +3754,97 @@ static inline BTLA_CODE gemv_2bit_fp32_fp32(const float* A, int lda, const utils
 }
 
 template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_1bit_fp32_fp32(const float* A, int lda, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b1ptr = (utils::bit1x8*)B.b1ptr;
+
+  int blks = k / blocksize;
+  int constexpr NReg = NTILE / 8;
+  int constexpr MReg = MTILE;
+  int constexpr FullRange = 1 << (1 - 1);
+  __m256 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm256_setzero_ps();
+  }
+  auto vbias = _mm256_set1_epi8(FullRange);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+  int constexpr KTILE = 1;
+  for (int ib = 0; ib < blks; ib += 1) {
+    auto bsptr = B.sptr + ib * B.ldzp;
+
+    __m256 acc_loc[NReg * MReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      acc_loc[i] = _mm256_setzero_ps();
+    }
+    int constexpr Unroll = 4;
+    assert((blocksize % 4) == 0);
+    assert(tmpsize >= NTILE * Unroll);
+
+    if (B.zpptr) {
+      __m256i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < Unroll; i++) {
+        memcpy(tmp + i * NTILE, bzptr, NTILE);
+      }
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = _mm256_loadu_si256((const __m256i*)(tmp + i * 32));
+        bzp[i] = _mm256_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += Unroll) {
+        for (int i = 0; i < NReg; i++) {
+          auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+          vb1 = _mm256_srli_epi32(vb1, 2);
+          vb1 = _mm256_sub_epi8(vb1, bzp[i]);
+          _mm256_storeu_si256((__m256i*)(tmp + 32 * i), vb1);
+          b1ptr += 8 * Unroll / 8;
+        }
+        accumulate_fp32_s8_fp32<MTILE, NReg, Unroll>(A + ib * blocksize + ik, lda, tmp, acc_loc);
+      }
+
+    } else {
+      for (int ik = 0; ik < blocksize; ik += Unroll) {
+        for (int i = 0; i < NReg; i++) {
+          auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+          vb1 = _mm256_srli_epi32(vb1, 2);
+          vb1 = _mm256_sub_epi8(vb1, vbias);
+          _mm256_storeu_si256((__m256i*)(tmp + 32 * i), vb1);
+          b1ptr += 8 * Unroll / 8;
+        }
+        accumulate_fp32_s8_fp32<MTILE, NReg, Unroll>(A + ib * blocksize + ik, lda, tmp, acc_loc);
+      }
+    }
+
+    __m256 v_b_scale[NReg];
+    for (int i = 0; i < NReg; i++) {
+      v_b_scale[i] = load_T_fp32(bsptr + i * 8);
+    }
+    for (int im = 0; im < MTILE; im++) {
+      for (int in = 0; in < NReg; in++) {
+        acc[im * NReg + in] = _mm256_fmadd_ps(acc_loc[im * NReg + in], v_b_scale[in], acc[im * NReg + in]);
+      }
+    }
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm256_storeu_ps(C + i * 8 + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
 static inline BTLA_CODE gemv_3bit_fp32_fp32(const float* A, int lda, const utils::GemvParamB<ScaleT>& B, float* C,
                                             int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
   auto b2ptr = (utils::bit2x4*)B.b2ptr;
   auto b1ptr = (utils::bit1x8*)B.b1ptr;
 
   int blks = k / blocksize;
+  int constexpr FullRange = 1 << (3 - 1);
   int constexpr NReg = NTILE / 8;
   int constexpr MReg = MTILE;
   // Initialize accumulator with zeros
@@ -3510,7 +3859,7 @@ static inline BTLA_CODE gemv_3bit_fp32_fp32(const float* A, int lda, const utils
   auto vsfhl_mask_y = _mm256_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
                                       13, 9, 5, 1, 12, 8, 4, 0);
   auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
-  auto vbias = _mm256_set1_epi8(4);
+  auto vbias = _mm256_set1_epi8(FullRange);
 
   const __m256i highMask = _mm256_set1_epi8(0x04);
   const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
@@ -4039,12 +4388,123 @@ static inline BTLA_CODE gemv_4bit_u8s8_fp32(const utils::GemvParamA& A, const ut
 }
 
 template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_1bit_u8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+
+  int blks = k / blocksize;
+  int constexpr FullRange = 1 << (1 - 1);
+  int constexpr NReg = NTILE / 8;
+  int constexpr MReg = MTILE;
+  __m256 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm256_setzero_ps();
+  }
+  const __m256i onesu8 = _mm256_set1_epi8(1);
+  const __m256i vbias = _mm256_set1_epi8(FullRange);
+  const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+  int constexpr KTILE = 4;
+  for (int ib = 0; ib < blks; ib += 1) {
+    __m256i iacc[NReg * MReg];
+    __m256i bacc[NReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      iacc[i] = _mm256_setzero_si256();
+    }
+    for (int i = 0; i < NReg; i++) {
+      bacc[i] = _mm256_setzero_si256();
+    }
+    if (B.zpptr) {
+      __m256i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 8, vindex);
+        bzp[i] = _mm256_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m256i va = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            vb1 = _mm256_srli_epi32(vb1, 2);
+            vb1 = _mm256_sub_epi8(vb1, bzp[i]);
+            bacc[i] = _mm256_dpbusd_avx2_epi32(bacc[i], onesu8, vb1);
+            iacc[i] = _mm256_dpbusd_avx2_epi32(iacc[i], va, vb1);
+            b1ptr += 8 * KTILE / 8;
+          }
+        } else {
+          __m256i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            vb1 = _mm256_srli_epi32(vb1, 2);
+            vb1 = _mm256_sub_epi8(vb1, bzp[i]);
+            bacc[i] = _mm256_dpbusd_avx2_epi32(bacc[i], onesu8, vb1);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm256_dpbusd_avx2_epi32(iacc[j * NReg + i], va[j], vb1);
+            }
+            b1ptr += 8 * KTILE / 8;
+          }
+        }
+      }
+    } else {
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m256i va = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            vb1 = _mm256_srli_epi32(vb1, 2);
+            vb1 = _mm256_sub_epi8(vb1, vbias);
+            bacc[i] = _mm256_dpbusd_avx2_epi32(bacc[i], onesu8, vb1);
+            iacc[i] = _mm256_dpbusd_avx2_epi32(iacc[i], va, vb1);
+            b1ptr += 8 * KTILE / 8;
+          }
+        } else {
+          __m256i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            vb1 = _mm256_srli_epi32(vb1, 2);
+            vb1 = _mm256_sub_epi8(vb1, vbias);
+            bacc[i] = _mm256_dpbusd_avx2_epi32(bacc[i], onesu8, vb1);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm256_dpbusd_avx2_epi32(iacc[j * NReg + i], va[j], vb1);
+            }
+            b1ptr += 8 * KTILE / 8;
+          }
+        }
+      }
+    }
+
+    gemv_remove_zp<NReg, MReg>(A.zpptr + ib, A.ldzp, iacc, bacc);
+    gemv_dequant_s32fp32<ScaleT, NReg, MTILE>(A.sptr + ib, A.ldzp, B.sptr + ib * B.ldzp, iacc, acc);
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm256_storeu_ps(C + i * 8 + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
 static inline BTLA_CODE gemv_3bit_u8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
                                             int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
   auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
   auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
 
   int blks = k / blocksize;
+  int constexpr FullRange = 1 << (3 - 1);
   int constexpr NReg = NTILE / 8;
   int constexpr MReg = MTILE;
   __m256 acc[NReg * MReg];
@@ -4058,7 +4518,7 @@ static inline BTLA_CODE gemv_3bit_u8s8_fp32(const utils::GemvParamA& A, const ut
                                       13, 9, 5, 1, 12, 8, 4, 0);
   auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
   const __m256i onesu8 = _mm256_set1_epi8(1);
-  const __m256i vbias = _mm256_set1_epi8(4);
+  const __m256i vbias = _mm256_set1_epi8(FullRange);
   const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
                                       4, 4, 4, 0, 0, 0, 0);
 
@@ -4685,6 +5145,200 @@ namespace vnni {
 #endif
 
 template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_1bit_u8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+
+  int blks = k / blocksize;
+  int constexpr FullRange = 1 << (1 - 1);
+  int constexpr NReg = NTILE / 8;
+  int constexpr MReg = MTILE;
+  __m256 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm256_setzero_ps();
+  }
+  const __m256i onesu8 = _mm256_set1_epi8(1);
+  const __m256i vbias = _mm256_set1_epi8(FullRange);
+  const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+  int constexpr KTILE = 4;
+  for (int ib = 0; ib < blks; ib += 1) {
+    __m256i iacc[NReg * MReg];
+    __m256i bacc[NReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      iacc[i] = _mm256_setzero_si256();
+    }
+    for (int i = 0; i < NReg; i++) {
+      bacc[i] = _mm256_setzero_si256();
+    }
+    if (B.zpptr) {
+      __m256i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 8, vindex);
+        bzp[i] = _mm256_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m256i va = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            vb1 = _mm256_srli_epi32(vb1, 2);
+            vb1 = _mm256_sub_epi8(vb1, bzp[i]);
+            bacc[i] = _mm256_dpbusd_avx_epi32(bacc[i], onesu8, vb1);
+            iacc[i] = _mm256_dpbusd_avx_epi32(iacc[i], va, vb1);
+            b1ptr += 8 * KTILE / 8;
+          }
+        } else {
+          __m256i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            vb1 = _mm256_srli_epi32(vb1, 2);
+            vb1 = _mm256_sub_epi8(vb1, bzp[i]);
+            bacc[i] = _mm256_dpbusd_avx_epi32(bacc[i], onesu8, vb1);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm256_dpbusd_avx_epi32(iacc[j * NReg + i], va[j], vb1);
+            }
+            b1ptr += 8 * KTILE / 8;
+          }
+        }
+      }
+    } else {
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m256i va = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            vb1 = _mm256_srli_epi32(vb1, 2);
+            vb1 = _mm256_sub_epi8(vb1, vbias);
+            bacc[i] = _mm256_dpbusd_avx_epi32(bacc[i], onesu8, vb1);
+            iacc[i] = _mm256_dpbusd_avx_epi32(iacc[i], va, vb1);
+            b1ptr += 8 * KTILE / 8;
+          }
+        } else {
+          __m256i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+            vb1 = _mm256_srli_epi32(vb1, 2);
+            vb1 = _mm256_sub_epi8(vb1, vbias);
+            bacc[i] = _mm256_dpbusd_avx_epi32(bacc[i], onesu8, vb1);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm256_dpbusd_avx_epi32(iacc[j * NReg + i], va[j], vb1);
+            }
+            b1ptr += 8 * KTILE / 8;
+          }
+        }
+      }
+    }
+
+    gemv_remove_zp<NReg, MReg>(A.zpptr + ib, A.ldzp, iacc, bacc);
+    gemv_dequant_s32fp32<ScaleT, NReg, MTILE>(A.sptr + ib, A.ldzp, B.sptr + ib * B.ldzp, iacc, acc);
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm256_storeu_ps(C + i * 8 + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_1bit_s8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+
+  int blks = k / blocksize;
+  int constexpr FullRange = 1 << (1 - 1);
+  int constexpr NReg = NTILE / 8;
+  int constexpr MReg = MTILE;
+  __m256 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm256_setzero_ps();
+  }
+
+  const __m256i onesu8 = _mm256_set1_epi8(1);
+  const __m256i vbias = _mm256_set1_epi8(FullRange);
+  const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0);
+
+  const __m256i highMask = _mm256_set1_epi8(0x04);
+  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
+  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
+  int constexpr KTILE = 4;
+  for (int ib = 0; ib < blks; ib += 1) {
+    __m256i iacc[NReg * MReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      iacc[i] = _mm256_setzero_si256();
+    }
+    if (B.zpptr) {
+      __m256i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 8, vindex);
+        bzp[i] = _mm256_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        __m256i va[MReg];
+        for (int i = 0; i < MReg; i++) {
+          va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+        }
+        for (int i = 0; i < NReg; i++) {
+          auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+          vb1 = _mm256_srli_epi32(vb1, 2);
+          vb1 = _mm256_sub_epi8(vb1, bzp[i]);
+          for (int j = 0; j < MReg; j++) {
+            auto vsb = _mm256_sign_epi8(vb1, va[j]);
+            auto vabsa = _mm256_sign_epi8(va[j], va[j]);
+            iacc[j * NReg + i] = _mm256_dpbusd_avx_epi32(iacc[j * NReg + i], vabsa, vsb);
+          }
+          b1ptr += 8 * KTILE / 8;
+        }
+      }
+    } else {
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        __m256i va[MReg];
+        for (int i = 0; i < MReg; i++) {
+          va[i] = _mm256_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+        }
+        for (int i = 0; i < NReg; i++) {
+          auto vb1 = unpack_1bits(b1ptr, bit1Shift_1, bit1Mask, bit1Shift_2, highMask);
+          vb1 = _mm256_srli_epi32(vb1, 2);
+          vb1 = _mm256_sub_epi8(vb1, vbias);
+          for (int j = 0; j < MReg; j++) {
+            auto vsb = _mm256_sign_epi8(vb1, va[j]);
+            auto vabsa = _mm256_sign_epi8(va[j], va[j]);
+            iacc[j * NReg + i] = _mm256_dpbusd_avx_epi32(iacc[j * NReg + i], vabsa, vsb);
+          }
+          b1ptr += 8 * KTILE / 8;
+        }
+      }
+    }
+
+    gemv_dequant_s32fp32<ScaleT, NReg, MTILE>(A.sptr + ib, A.ldzp, B.sptr + ib * B.ldzp, iacc, acc);
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm256_storeu_ps(C + i * 8 + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
 static inline BTLA_CODE gemv_4bit_u8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
                                             int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
   auto& a8ptr = A.aptr;
@@ -4693,6 +5347,7 @@ static inline BTLA_CODE gemv_4bit_u8s8_fp32(const utils::GemvParamA& A, const ut
   auto& azptr = A.zpptr;
 
   int blks = k / blocksize;
+  int constexpr FullRange = 1 << (4 - 1);
   int constexpr NReg = NTILE / 8;
   int constexpr MReg = MTILE;
   // Initialize accumulator with zeros
@@ -4703,7 +5358,7 @@ static inline BTLA_CODE gemv_4bit_u8s8_fp32(const utils::GemvParamA& A, const ut
   uint32_t mask = 0x0f0f0f0f;
   auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
   const __m256i onesu8 = _mm256_set1_epi8(1);
-  const __m256i vbias = _mm256_set1_epi8(8);
+  const __m256i vbias = _mm256_set1_epi8(FullRange);
   const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
                                       4, 4, 4, 0, 0, 0, 0);
 
@@ -4794,13 +5449,14 @@ static inline BTLA_CODE gemv_4bit_s8s8_fp32(const utils::GemvParamA& A, const ut
   auto& asptr = A.sptr;
 
   int blks = k / blocksize;
+  int constexpr FullRange = 1 << (4 - 1);
   int constexpr NReg = NTILE / 8;
   int constexpr MReg = MTILE;
   __m256 acc[NReg * MReg];
   for (int i = 0; i < NReg * MReg; i++) {
     acc[i] = _mm256_setzero_ps();
   }
-  const __m256i vbias = _mm256_set1_epi8(8);
+  const __m256i vbias = _mm256_set1_epi8(FullRange);
   uint32_t mask = 0x0f0f0f0f;
   auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
   const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
@@ -4861,259 +5517,13 @@ static inline BTLA_CODE gemv_4bit_s8s8_fp32(const utils::GemvParamA& A, const ut
   return BTLA_CODE::Success;
 }
 
-template <typename ScaleT, int NTILE>
-static inline BTLA_CODE gemv_3bit_u8s8_fp32_align128(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B,
-                                                     float* C, int k, int ld_scaleb, int blocksize, int8_t* tmp,
-                                                     size_t tmpsize) {
-  auto a8ptr = A.aptr;
-  auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
-  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
-  auto asptr = A.sptr;
-  auto azptr = A.zpptr;
-
-  int blks = k / blocksize;
-  int constexpr NReg = NTILE / 8;
-  // Initialize accumulator with zeros
-  __m256 acc[NReg];
-  int constexpr EltPadding = 128;
-  static_assert(NTILE % 8 == 0);
-  int constexpr KTILE = 4;
-  int constexpr UnpackElt = EltPadding / 8 / KTILE;
-  int constexpr TotalElt = UnpackElt * NTILE * KTILE;
-  int constexpr Loop128 = TotalElt / 128;
-  int8_t UnpackBuf[TotalElt];
-  for (int i = 0; i < NReg; i++) {
-    acc[i] = _mm256_setzero_ps();
-  }
-
-  uint32_t mask = 0x0f0f0f0f;
-  auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
-  const __m256i onesu8 = _mm256_set1_epi8(1);
-  const __m256i lowMask = _mm256_set1_epi8(0x03);
-  const __m256i highMask = _mm256_set1_epi8(0x04);
-  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
-  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
-  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
-  const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
-                                      4, 4, 4, 0, 0, 0, 0);
-  auto bit3_interleave_decompress_pack128 = [&](utils::bit2x4* src1, utils::bit1x8* src2, int8_t* dst) {
-    __m256i bit2_data = _mm256_loadu_si256((const __m256i*)src1);
-    int32_t* bit1_ptr = reinterpret_cast<int32_t*>(src2);
-    for (int i = 0; i < 4; i++) {
-      auto bit1x32 = _mm256_set1_epi32(bit1_ptr[i]);
-      bit1x32 = _mm256_srlv_epi32(bit1x32, bit1Shift_1);
-      bit1x32 = _mm256_and_si256(bit1x32, bit1Mask);
-      bit1x32 = _mm256_mullo_epi32(bit1x32, bit1Shift_2);
-      bit1x32 = _mm256_and_si256(highMask, bit1x32);
-
-      auto bit2x32 = _mm256_and_si256(lowMask, _mm256_srli_epi16(bit2_data, 2 * i));
-      auto res = _mm256_add_epi8(bit1x32, bit2x32);
-      res = _mm256_sub_epi8(res, highMask);
-      _mm256_storeu_si256((__m256i*)(dst + 32 * i), res);
-    }
-  };
-  assert(azptr);
-  for (int ib = 0; ib < blks; ib += 1) {
-    __m256i iacc[NReg];
-    __m256i bacc[NReg];
-    for (int i = 0; i < NReg; i++) {
-      iacc[i] = _mm256_setzero_si256();
-      bacc[i] = _mm256_setzero_si256();
-    }
-    if (B.zpptr) {
-      __m256i bzp[NReg];
-      auto bzptr = B.zpptr + ib * ld_scaleb;
-      for (int i = 0; i < NReg; i++) {
-        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 8, vindex);
-      }
-      for (int ik = 0; ik < blocksize; ik += KTILE * UnpackElt) {
-        for (int il = 0; il < Loop128; il++) {
-          bit3_interleave_decompress_pack128(b2ptr, b1ptr, UnpackBuf + il * 128);
-          b2ptr += 128 / 4;
-          b1ptr += 128 / 8;
-        }
-        for (int iu = 0; iu < UnpackElt; iu++) {
-          auto va = _mm256_set1_epi32(*(int*)(a8ptr + iu * KTILE));
-          for (int i = 0; i < NReg; i++) {
-            auto vb = _mm256_loadu_si256((const __m256i*)(UnpackBuf + iu * NTILE * KTILE + i * 32));
-            vb = _mm256_sub_epi8(vb, bzp[i]);
-            iacc[i] = _mm256_dpbusd_avx_epi32(iacc[i], va, vb);
-            bacc[i] = _mm256_dpbusd_avx_epi32(bacc[i], onesu8, vb);
-          }
-        }
-        a8ptr += KTILE * UnpackElt;
-      }
-    } else {
-      for (int ik = 0; ik < blocksize; ik += KTILE * UnpackElt) {
-        for (int il = 0; il < Loop128; il++) {
-          bit3_interleave_decompress_pack128(b2ptr, b1ptr, UnpackBuf + il * 128);
-          b2ptr += 128 / 4;
-          b1ptr += 128 / 8;
-        }
-        for (int iu = 0; iu < UnpackElt; iu++) {
-          auto va = _mm256_set1_epi32(*(int*)(a8ptr + iu * KTILE));
-          for (int i = 0; i < NReg; i++) {
-            auto vb = _mm256_loadu_si256((const __m256i*)(UnpackBuf + iu * NTILE * KTILE + i * 32));
-            iacc[i] = _mm256_dpbusd_avx_epi32(iacc[i], va, vb);
-            bacc[i] = _mm256_dpbusd_avx_epi32(bacc[i], onesu8, vb);
-          }
-        }
-        a8ptr += KTILE * UnpackElt;
-      }
-    }
-
-    const __m256 v_a_scale = _mm256_set1_ps(*(asptr + ib));
-    auto zp = int(azptr[ib]);
-    const __m256i v_a_zp = _mm256_set1_epi32(zp);
-    auto bsptr = B.sptr + ib * ld_scaleb;
-    for (int i = 0; i < NReg; i++) {
-      bacc[i] = _mm256_mullo_epi32(v_a_zp, bacc[i]);
-      iacc[i] = _mm256_sub_epi32(iacc[i], bacc[i]);
-      __m256 v_b_scale;
-      if constexpr (std::is_same_v<ScaleT, float>) {
-        v_b_scale = _mm256_loadu_ps(bsptr + i * 8);
-      } else if constexpr (std::is_same_v<ScaleT, utils::bf16>) {
-        auto tmp = _mm_loadu_si128((const __m128i*)(bsptr + i * 8));
-        v_b_scale = kernel::avx2::ymm_cvt_bf16_fp32(tmp);
-      }
-      v_b_scale = _mm256_mul_ps(v_a_scale, v_b_scale);
-      auto tmp = _mm256_cvtepi32_ps(iacc[i]);
-      acc[i] = _mm256_fmadd_ps(tmp, v_b_scale, acc[i]);
-    }
-  }
-
-  for (int i = 0; i < NReg; i++) {
-    _mm256_storeu_ps(C + i * 8, acc[i]);
-  }
-  return BTLA_CODE::Success;
-}
-
-template <typename ScaleT, int NTILE>
-static inline BTLA_CODE gemv_3bit_s8s8_fp32_align128(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B,
-                                                     float* C, int k, int ld_scaleb, int blocksize, int8_t* tmp,
-                                                     size_t tmpsize) {
-  auto a8ptr = A.aptr;
-  auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
-  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
-  auto asptr = A.sptr;
-  auto azptr = A.zpptr;
-
-  int blks = k / blocksize;
-  int constexpr NReg = NTILE / 8;
-  // Initialize accumulator with zeros
-  __m256 acc[NReg];
-  int constexpr EltPadding = 128;
-  static_assert(NTILE % 8 == 0);
-  int constexpr KTILE = 4;
-  int constexpr UnpackElt = EltPadding / 8 / KTILE;
-  int constexpr TotalElt = UnpackElt * NTILE * KTILE;
-  int constexpr Loop128 = TotalElt / 128;
-  int8_t UnpackBuf[TotalElt];
-  for (int i = 0; i < NReg; i++) {
-    acc[i] = _mm256_setzero_ps();
-  }
-  uint32_t mask = 0x0f0f0f0f;
-  auto vmask = _mm256_set1_epi32(*reinterpret_cast<int*>(&mask));
-  const __m256i lowMask = _mm256_set1_epi8(0x03);
-  const __m256i highMask = _mm256_set1_epi8(0x04);
-  const __m256i bit1Mask = _mm256_set1_epi32(0x0F);
-  const __m256i bit1Shift_1 = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
-  const __m256i bit1Shift_2 = _mm256_set1_epi32((1 << 23) + (1 << 16) + (1 << 9) + (1 << 2));
-  const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
-                                      4, 4, 4, 0, 0, 0, 0);
-  auto bit3_interleave_decompress_pack128 = [&](utils::bit2x4* src1, utils::bit1x8* src2, int8_t* dst) {
-    __m256i bit2_data = _mm256_loadu_si256((const __m256i*)src1);
-    int32_t* bit1_ptr = reinterpret_cast<int32_t*>(src2);
-    for (int i = 0; i < 4; i++) {
-      auto bit1x32 = _mm256_set1_epi32(bit1_ptr[i]);
-      bit1x32 = _mm256_srlv_epi32(bit1x32, bit1Shift_1);
-      bit1x32 = _mm256_and_si256(bit1x32, bit1Mask);
-      bit1x32 = _mm256_mullo_epi32(bit1x32, bit1Shift_2);
-      bit1x32 = _mm256_and_si256(highMask, bit1x32);
-
-      auto bit2x32 = _mm256_and_si256(lowMask, _mm256_srli_epi16(bit2_data, 2 * i));
-      auto res = _mm256_add_epi8(bit1x32, bit2x32);
-      res = _mm256_slli_epi32(res, 5);
-      _mm256_storeu_si256((__m256i*)(dst + 32 * i), res);
-    }
-  };
-  for (int ib = 0; ib < blks; ib += 1) {
-    __m256i iacc[NReg];
-    for (int i = 0; i < NReg; i++) {
-      iacc[i] = _mm256_setzero_si256();
-    }
-    if (B.zpptr) {
-      __m256i bzp[NReg];
-      auto bzptr = B.zpptr + ib * ld_scaleb;
-      for (int i = 0; i < NReg; i++) {
-        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 8, vindex);
-      }
-      for (int ik = 0; ik < blocksize; ik += KTILE * UnpackElt) {
-        for (int il = 0; il < Loop128; il++) {
-          bit3_interleave_decompress_pack128(b2ptr, b1ptr, UnpackBuf + il * 128);
-          b2ptr += 128 / 4;
-          b1ptr += 128 / 8;
-        }
-        for (int iu = 0; iu < UnpackElt; iu++) {
-          auto va = _mm256_set1_epi32(*(int*)(a8ptr + iu * KTILE));
-          auto vabsa = _mm256_sign_epi8(va, va);
-          for (int i = 0; i < NReg; i++) {
-            auto vb = _mm256_loadu_si256((const __m256i*)(UnpackBuf + iu * NTILE * KTILE + i * 32));
-            vb = _mm256_sub_epi8(vb, bzp[i]);
-            vb = _mm256_sign_epi8(vb, va);
-            iacc[i] = _mm256_dpbusd_avx_epi32(iacc[i], vabsa, vb);
-          }
-        }
-        a8ptr += KTILE * UnpackElt;
-      }
-    } else {
-      for (int ik = 0; ik < blocksize; ik += KTILE * UnpackElt) {
-        for (int il = 0; il < Loop128; il++) {
-          bit3_interleave_decompress_pack128(b2ptr, b1ptr, UnpackBuf + il * 128);
-          b2ptr += 128 / 4;
-          b1ptr += 128 / 8;
-        }
-        for (int iu = 0; iu < UnpackElt; iu++) {
-          auto va = _mm256_set1_epi32(*(int*)(a8ptr + iu * KTILE));
-          auto vabsa = _mm256_sign_epi8(va, va);
-          for (int i = 0; i < NReg; i++) {
-            auto vb = _mm256_loadu_si256((const __m256i*)(UnpackBuf + iu * NTILE * KTILE + i * 32));
-            vb = _mm256_sign_epi8(vb, va);
-            iacc[i] = _mm256_dpbusd_avx_epi32(iacc[i], vabsa, vb);
-          }
-        }
-        a8ptr += KTILE * UnpackElt;
-      }
-    }
-
-    const __m256 v_a_scale = _mm256_set1_ps(*(asptr + ib));
-    auto bsptr = B.sptr + ib * ld_scaleb;
-    for (int i = 0; i < NReg; i++) {
-      __m256 v_b_scale;
-      if constexpr (std::is_same_v<ScaleT, float>) {
-        v_b_scale = _mm256_loadu_ps(bsptr + i * 8);
-      } else if constexpr (std::is_same_v<ScaleT, utils::bf16>) {
-        auto tmp = _mm_loadu_si128((const __m128i*)(bsptr + i * 8));
-        v_b_scale = kernel::avx2::ymm_cvt_bf16_fp32(tmp);
-      }
-      v_b_scale = _mm256_mul_ps(v_a_scale, v_b_scale);
-      auto tmp = _mm256_cvtepi32_ps(iacc[i]);
-      acc[i] = _mm256_fmadd_ps(tmp, v_b_scale, acc[i]);
-    }
-  }
-
-  for (int i = 0; i < NReg; i++) {
-    _mm256_storeu_ps(C + i * 8, acc[i]);
-  }
-  return BTLA_CODE::Success;
-}
-
 template <typename ScaleT, int NTILE, int MTILE>
 static inline BTLA_CODE gemv_2bit_u8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
                                             int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
   auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
 
   int blks = k / blocksize;
+  int constexpr FullRange = 1 << (2 - 1);
   int constexpr NReg = NTILE / 8;
   int constexpr MReg = MTILE;
   __m256 acc[NReg * MReg];
@@ -5127,7 +5537,7 @@ static inline BTLA_CODE gemv_2bit_u8s8_fp32(const utils::GemvParamA& A, const ut
                                       13, 9, 5, 1, 12, 8, 4, 0);
   auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
   const __m256i onesu8 = _mm256_set1_epi8(1);
-  const __m256i vbias = _mm256_set1_epi8(2);
+  const __m256i vbias = _mm256_set1_epi8(FullRange);
   const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
                                       4, 4, 4, 0, 0, 0, 0);
   int constexpr KTILE = 4;
@@ -5220,6 +5630,7 @@ static inline BTLA_CODE gemv_2bit_s8s8_fp32(const utils::GemvParamA& A, const ut
   auto b2ptr = reinterpret_cast<utils::bit2x4*>(B.b2ptr);
 
   int blks = k / blocksize;
+  int constexpr FullRange = 1 << (2 - 1);
   int constexpr NReg = NTILE / 8;
   int constexpr MReg = MTILE;
   __m256 acc[NReg * MReg];
@@ -5233,7 +5644,7 @@ static inline BTLA_CODE gemv_2bit_s8s8_fp32(const utils::GemvParamA& A, const ut
                                       13, 9, 5, 1, 12, 8, 4, 0);
   auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
   const __m256i onesu8 = _mm256_set1_epi8(1);
-  const __m256i vbias = _mm256_set1_epi8(2);
+  const __m256i vbias = _mm256_set1_epi8(FullRange);
   const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
                                       4, 4, 4, 0, 0, 0, 0);
   int constexpr KTILE = 4;
@@ -5302,6 +5713,7 @@ static inline BTLA_CODE gemv_3bit_u8s8_fp32(const utils::GemvParamA& A, const ut
   auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
 
   int blks = k / blocksize;
+  int constexpr FullRange = 1 << (3 - 1);
   int constexpr NReg = NTILE / 8;
   int constexpr MReg = MTILE;
   __m256 acc[NReg * MReg];
@@ -5315,7 +5727,7 @@ static inline BTLA_CODE gemv_3bit_u8s8_fp32(const utils::GemvParamA& A, const ut
                                       13, 9, 5, 1, 12, 8, 4, 0);
   auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
   const __m256i onesu8 = _mm256_set1_epi8(1);
-  const __m256i vbias = _mm256_set1_epi8(4);
+  const __m256i vbias = _mm256_set1_epi8(FullRange);
   const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
                                       4, 4, 4, 0, 0, 0, 0);
 
@@ -5427,6 +5839,7 @@ static inline BTLA_CODE gemv_3bit_s8s8_fp32(const utils::GemvParamA& A, const ut
   auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
 
   int blks = k / blocksize;
+  int constexpr FullRange = 1 << (3 - 1);
   int constexpr NReg = NTILE / 8;
   int constexpr MReg = MTILE;
   __m256 acc[NReg * MReg];
@@ -5440,7 +5853,7 @@ static inline BTLA_CODE gemv_3bit_s8s8_fp32(const utils::GemvParamA& A, const ut
                                       13, 9, 5, 1, 12, 8, 4, 0);
   auto vorder_y = _mm256_set_epi32(1, 1, 1, 1, 0, 0, 0, 0);
   const __m256i onesu8 = _mm256_set1_epi8(1);
-  const __m256i vbias = _mm256_set1_epi8(4);
+  const __m256i vbias = _mm256_set1_epi8(FullRange);
   const auto vindex = _mm256_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
                                       4, 4, 4, 0, 0, 0, 0);
 

--- a/bestla/bestla/kernel_avx2.h
+++ b/bestla/bestla/kernel_avx2.h
@@ -550,7 +550,7 @@ static inline BTLA_CODE decompress_kblock_s4_s8(utils::int4x2* srcptr, int8_t* z
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::int4x2 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -764,7 +764,7 @@ static inline BTLA_CODE decompress_kblock_s2_s8(utils::bit2x4* bit2ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -1022,7 +1022,7 @@ static inline BTLA_CODE decompress_kblock_s3_s8(utils::bit2x4* bit2ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -1247,7 +1247,7 @@ static inline BTLA_CODE decompress_kblock_s1_s8(utils::bit1x8* bit1ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -1500,7 +1500,7 @@ static inline BTLA_CODE decompress_kblock_s5_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -1814,9 +1814,9 @@ static inline BTLA_CODE decompress_kblock_s7_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset,
                                                 int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
-                                    int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
-                                    int row, int8_t* tmp, size_t tmpsize);
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr,
+                                    int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp, int n_offset,
+                                    int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
       if constexpr (PackRow == 1) {
@@ -2077,7 +2077,7 @@ static inline BTLA_CODE decompress_kblock_s6_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;

--- a/bestla/bestla/kernel_avx512f.h
+++ b/bestla/bestla/kernel_avx512f.h
@@ -2594,7 +2594,7 @@ template <int PackRow, int NTILE>
 inline BTLA_CODE decompress_kblock_s4_s8(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                          int n_offset, int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::int4x2 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -2816,7 +2816,7 @@ static inline BTLA_CODE decompress_kblock_s2_s8(utils::bit2x4* bit2ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -3074,7 +3074,7 @@ static inline BTLA_CODE decompress_kblock_s3_s8(utils::bit2x4* bit2ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -3296,7 +3296,7 @@ static inline BTLA_CODE decompress_kblock_s1_s8(utils::bit1x8* bit1ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -3545,7 +3545,7 @@ static inline BTLA_CODE decompress_kblock_s5_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -3859,9 +3859,9 @@ static inline BTLA_CODE decompress_kblock_s7_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset,
                                                 int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
-                                    int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
-                                    int row, int8_t* tmp, size_t tmpsize);
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr,
+                                    int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp, int n_offset,
+                                    int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
       if constexpr (PackRow == 1) {
@@ -4130,7 +4130,7 @@ static inline BTLA_CODE decompress_kblock_s6_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;

--- a/bestla/bestla/kernel_avx512f.h
+++ b/bestla/bestla/kernel_avx512f.h
@@ -4792,9 +4792,10 @@ static inline BTLA_CODE gemv_4bit_fp32_fp32(const float* A, int lda, const utils
   for (int i = 0; i < NReg * MReg; i++) {
     acc[i] = _mm512_setzero_ps();
   }
+  int constexpr FullRange = 1 << (4 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
   uint32_t mask = 0x0f0f0f0f;
   auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));
-  auto vbias = _mm512_set1_epi8(8);
   for (int ib = 0; ib < blks; ib += 1) {
     auto bsptr = B.sptr + ib * B.ldzp;
     __m512 v_b_scale[NReg];
@@ -4858,9 +4859,10 @@ static inline BTLA_CODE gemv_2bit_fp32_fp32(const float* A, int lda, const utils
   for (int i = 0; i < NReg * MReg; i++) {
     acc[i] = _mm512_setzero_ps();
   }
+  int constexpr FullRange = 1 << (2 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
   uint64_t mask0 = 0x0303030303030303;
   auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
-  auto vbias = _mm512_set1_epi8(2);
   auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
   auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
                                       13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
@@ -4944,9 +4946,10 @@ static inline BTLA_CODE gemv_3bit_fp32_fp32(const float* A, int lda, const utils
   for (int i = 0; i < NReg * MReg; i++) {
     acc[i] = _mm512_setzero_ps();
   }
+  int constexpr FullRange = 1 << (3 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
   uint64_t mask0 = 0x0303030303030303;
   auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
-  auto vbias = _mm512_set1_epi8(4);
   auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
   auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
                                       13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
@@ -4999,6 +5002,89 @@ static inline BTLA_CODE gemv_3bit_fp32_fp32(const float* A, int lda, const utils
           vb = _mm512_sub_epi8(vb, vbias);
           _mm512_storeu_si512((__m512i*)(tmp + 64 * i), vb);
           b2ptr += VLen * Unroll / 4;
+          b1ptr += VLen * Unroll / 8;
+        }
+        accumulate_fp32_s8_fp32<MTILE, NReg, Unroll>(A + ib * blocksize + ik, lda, tmp, acc_loc);
+      }
+    }
+
+    __m512 v_b_scale[NReg];
+    for (int i = 0; i < NReg; i++) {
+      v_b_scale[i] = load_T_fp32(bsptr + i * VLen);
+    }
+    for (int im = 0; im < MTILE; im++) {
+      for (int in = 0; in < NReg; in++) {
+        acc[im * NReg + in] = _mm512_fmadd_ps(acc_loc[im * NReg + in], v_b_scale[in], acc[im * NReg + in]);
+      }
+    }
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm512_storeu_ps(C + i * VLen + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_1bit_fp32_fp32(const float* A, int lda, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b1ptr = (utils::bit1x8*)B.b1ptr;
+
+  int constexpr VLen = 16;
+  int blks = k / blocksize;
+  int constexpr NReg = NTILE / VLen;
+  int constexpr MReg = MTILE;
+  __m512 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm512_setzero_ps();
+  }
+  int constexpr FullRange = 1 << (1 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
+
+  auto zmm_0x04 = _mm512_set1_epi8(0x04);
+  auto zmm_0x00 = _mm512_set1_epi8(0x00);
+  int constexpr KTILE = 1;
+  for (int ib = 0; ib < blks; ib += 1) {
+    auto bsptr = B.sptr + ib * B.ldzp;
+
+    __m512 acc_loc[NReg * MReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      acc_loc[i] = _mm512_setzero_ps();
+    }
+    int constexpr Unroll = 4;
+    assert((blocksize % 4) == 0);
+    assert(tmpsize >= NTILE * Unroll);
+
+    if (B.zpptr) {
+      __m512i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < Unroll; i++) {
+        memcpy(tmp + i * NTILE, bzptr, NTILE);
+      }
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = _mm512_loadu_si512((const __m512i*)(tmp + i * 64));
+        bzp[i] = _mm512_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += Unroll) {
+        for (int i = 0; i < NReg; i++) {
+          auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+          vb1 = _mm512_srli_epi32(vb1, 2);
+          vb1 = _mm512_sub_epi8(vb1, bzp[i]);
+          _mm512_storeu_si512((__m512i*)(tmp + 64 * i), vb1);
+          b1ptr += VLen * Unroll / 8;
+        }
+        accumulate_fp32_s8_fp32<MTILE, NReg, Unroll>(A + ib * blocksize + ik, lda, tmp, acc_loc);
+      }
+
+    } else {
+      for (int ik = 0; ik < blocksize; ik += Unroll) {
+        for (int i = 0; i < NReg; i++) {
+          auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+          vb1 = _mm512_srli_epi32(vb1, 2);
+          vb1 = _mm512_sub_epi8(vb1, vbias);
+          _mm512_storeu_si512((__m512i*)(tmp + 64 * i), vb1);
           b1ptr += VLen * Unroll / 8;
         }
         accumulate_fp32_s8_fp32<MTILE, NReg, Unroll>(A + ib * blocksize + ik, lda, tmp, acc_loc);
@@ -5347,10 +5433,11 @@ static inline BTLA_CODE gemv_4bit_u8s8_fp32(const utils::GemvParamA& A, const ut
   for (int i = 0; i < NReg * MReg; i++) {
     acc[i] = _mm512_setzero_ps();
   }
+  int constexpr FullRange = 1 << (4 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
   uint32_t mask = 0x0f0f0f0f;
   auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));
   const __m512i onesu8 = _mm512_set1_epi8(1);
-  const __m512i vbias = _mm512_set1_epi8(8);
   const auto vindex = _mm512_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
                                       4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12,
                                       12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0);
@@ -5449,7 +5536,8 @@ static inline BTLA_CODE gemv_4bit_s8s8_fp32(const utils::GemvParamA& A, const ut
   for (int i = 0; i < NReg * MReg; i++) {
     acc[i] = _mm512_setzero_ps();
   }
-  const __m512i vbias = _mm512_set1_epi8(8);
+  int constexpr FullRange = 1 << (4 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
   uint32_t mask = 0x0f0f0f0f;
   auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));
   const auto vindex = _mm512_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
@@ -5523,14 +5611,14 @@ static inline BTLA_CODE gemv_2bit_u8s8_fp32(const utils::GemvParamA& A, const ut
   for (int i = 0; i < NReg * MReg; i++) {
     acc[i] = _mm512_setzero_ps();
   }
-
+  int constexpr FullRange = 1 << (2 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
   const auto onesu8 = _mm512_set1_epi8(1);
   const auto vindex = _mm512_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
                                       4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12,
                                       12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0);
   uint64_t mask0 = 0x0303030303030303;
   auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
-  auto vbias = _mm512_set1_epi8(2);
   auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
   auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
                                       13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
@@ -5632,14 +5720,14 @@ static inline BTLA_CODE gemv_2bit_s8s8_fp32(const utils::GemvParamA& A, const ut
   for (int i = 0; i < NReg * MReg; i++) {
     acc[i] = _mm512_setzero_ps();
   }
-
+  int constexpr FullRange = 1 << (2 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
   const auto onesu8 = _mm512_set1_epi8(1);
   const auto vindex = _mm512_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
                                       4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12,
                                       12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0);
   uint64_t mask0 = 0x0303030303030303;
   auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
-  auto vbias = _mm512_set1_epi8(2);
   auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
   auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
                                       13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
@@ -5718,9 +5806,10 @@ static inline BTLA_CODE gemv_3bit_u8s8_fp32(const utils::GemvParamA& A, const ut
   for (int i = 0; i < NReg * MReg; i++) {
     acc[i] = _mm512_setzero_ps();
   }
+  int constexpr FullRange = 1 << (3 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
   uint64_t mask0 = 0x0303030303030303;
   auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
-  auto vbias = _mm512_set1_epi8(4);
   auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
   auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
                                       13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
@@ -5843,9 +5932,10 @@ static inline BTLA_CODE gemv_3bit_s8s8_fp32(const utils::GemvParamA& A, const ut
   for (int i = 0; i < NReg * MReg; i++) {
     acc[i] = _mm512_setzero_ps();
   }
+  int constexpr FullRange = 1 << (3 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
   uint64_t mask0 = 0x0303030303030303;
   auto vmask0 = _mm512_set1_epi64(*(int64_t*)&mask0);
-  auto vbias = _mm512_set1_epi8(4);
   auto vshift_y = _mm512_set_epi32(6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0);
   auto vsfhl_mask_y = _mm512_set_epi8(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2,
                                       13, 9, 5, 1, 12, 8, 4, 0, 15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0,
@@ -5906,6 +5996,198 @@ static inline BTLA_CODE gemv_3bit_s8s8_fp32(const utils::GemvParamA& A, const ut
             iacc[j * NReg + i] = _mm512_dpbusd_epi32(iacc[j * NReg + i], vabsa, vsb);
           }
           b2ptr += VLen * KTILE / 4;
+          b1ptr += VLen * KTILE / 8;
+        }
+      }
+    }
+
+    gemv_dequant_s32fp32<ScaleT, NReg, MTILE>(A.sptr + ib, A.ldzp, B.sptr + ib * B.ldzp, iacc, acc);
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm512_storeu_ps(C + i * VLen + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_1bit_u8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+
+  int blks = k / blocksize;
+  int constexpr VLen = 16;
+  int constexpr NReg = NTILE / VLen;
+  int constexpr MReg = MTILE;
+  __m512 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm512_setzero_ps();
+  }
+  int constexpr FullRange = 1 << (1 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
+
+  auto zmm_0x04 = _mm512_set1_epi8(0x04);
+  auto zmm_0x00 = _mm512_set1_epi8(0x00);
+  const auto vindex = _mm512_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12,
+                                      12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0);
+  const auto onesu8 = _mm512_set1_epi8(1);
+  int constexpr KTILE = 4;
+  for (int ib = 0; ib < blks; ib += 1) {
+    __m512i iacc[NReg * MReg];
+    __m512i bacc[NReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      iacc[i] = _mm512_setzero_si512();
+    }
+    for (int i = 0; i < NReg; i++) {
+      bacc[i] = _mm512_setzero_si512();
+    }
+    if (B.zpptr) {
+      __m512i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 16, vindex);
+        bzp[i] = _mm512_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m512i va = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+            vb1 = _mm512_srli_epi32(vb1, 2);
+            vb1 = _mm512_sub_epi8(vb1, bzp[i]);
+            bacc[i] = _mm512_dpbusd_epi32(bacc[i], onesu8, vb1);
+            iacc[i] = _mm512_dpbusd_epi32(iacc[i], va, vb1);
+            b1ptr += VLen * KTILE / 8;
+          }
+        } else {
+          __m512i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+            vb1 = _mm512_srli_epi32(vb1, 2);
+            vb1 = _mm512_sub_epi8(vb1, bzp[i]);
+            bacc[i] = _mm512_dpbusd_epi32(bacc[i], onesu8, vb1);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm512_dpbusd_epi32(iacc[j * NReg + i], va[j], vb1);
+            }
+            b1ptr += VLen * KTILE / 8;
+          }
+        }
+      }
+    } else {
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        if constexpr (MTILE == 1) {
+          __m512i va = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik));
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+            vb1 = _mm512_srli_epi32(vb1, 2);
+            vb1 = _mm512_sub_epi8(vb1, vbias);
+            bacc[i] = _mm512_dpbusd_epi32(bacc[i], onesu8, vb1);
+            iacc[i] = _mm512_dpbusd_epi32(iacc[i], va, vb1);
+            b1ptr += VLen * KTILE / 8;
+          }
+        } else {
+          __m512i va[MReg];
+          for (int i = 0; i < MReg; i++) {
+            va[i] = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+          }
+          for (int i = 0; i < NReg; i++) {
+            auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+            vb1 = _mm512_srli_epi32(vb1, 2);
+            vb1 = _mm512_sub_epi8(vb1, vbias);
+            bacc[i] = _mm512_dpbusd_epi32(bacc[i], onesu8, vb1);
+            for (int j = 0; j < MReg; j++) {
+              iacc[j * NReg + i] = _mm512_dpbusd_epi32(iacc[j * NReg + i], va[j], vb1);
+            }
+            b1ptr += VLen * KTILE / 8;
+          }
+        }
+      }
+    }
+
+    gemv_remove_zp<NReg, MReg>(A.zpptr + ib, A.ldzp, iacc, bacc);
+    gemv_dequant_s32fp32<ScaleT, NReg, MTILE>(A.sptr + ib, A.ldzp, B.sptr + ib * B.ldzp, iacc, acc);
+  }
+
+  for (int j = 0; j < MReg; j++) {
+    for (int i = 0; i < NReg; i++) {
+      _mm512_storeu_ps(C + i * VLen + j * ldc, acc[j * NReg + i]);
+    }
+  }
+  return BTLA_CODE::Success;
+}
+
+template <typename ScaleT, int NTILE, int MTILE>
+static inline BTLA_CODE gemv_1bit_s8s8_fp32(const utils::GemvParamA& A, const utils::GemvParamB<ScaleT>& B, float* C,
+                                            int ldc, int k, int blocksize, int8_t* tmp, size_t tmpsize) {
+  auto b1ptr = reinterpret_cast<utils::bit1x8*>(B.b1ptr);
+
+  int blks = k / blocksize;
+  int constexpr VLen = 16;
+  int constexpr NReg = NTILE / VLen;
+  int constexpr MReg = MTILE;
+  __m512 acc[NReg * MReg];
+  for (int i = 0; i < NReg * MReg; i++) {
+    acc[i] = _mm512_setzero_ps();
+  }
+  int constexpr FullRange = 1 << (1 - 1);
+  auto vbias = _mm512_set1_epi8(FullRange);
+
+  auto zmm_0x04 = _mm512_set1_epi8(0x04);
+  auto zmm_0x00 = _mm512_set1_epi8(0x00);
+  const auto vindex = _mm512_set_epi8(12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4,
+                                      4, 4, 4, 0, 0, 0, 0, 12, 12, 12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0, 12, 12,
+                                      12, 12, 8, 8, 8, 8, 4, 4, 4, 4, 0, 0, 0, 0);
+  int constexpr KTILE = 4;
+  for (int ib = 0; ib < blks; ib += 1) {
+    __m512i iacc[NReg * MReg];
+    for (int i = 0; i < NReg * MReg; i++) {
+      iacc[i] = _mm512_setzero_si512();
+    }
+    if (B.zpptr) {
+      __m512i bzp[NReg];
+      auto bzptr = B.zpptr + ib * B.ldzp;
+      for (int i = 0; i < NReg; i++) {
+        bzp[i] = load_zp_epi8_broadcast_epi32(bzptr + i * 16, vindex);
+        bzp[i] = _mm512_add_epi8(bzp[i], vbias);
+      }
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        __m512i va[MReg];
+        for (int i = 0; i < MReg; i++) {
+          va[i] = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+        }
+        for (int i = 0; i < NReg; i++) {
+          auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+          vb1 = _mm512_srli_epi32(vb1, 2);
+          vb1 = _mm512_sub_epi8(vb1, bzp[i]);
+          for (int j = 0; j < MReg; j++) {
+            auto vsb = _mm512_sign_epi8(vb1, va[j]);
+            auto vabsa = _mm512_sign_epi8(va[j], va[j]);
+            iacc[j * NReg + i] = _mm512_dpbusd_epi32(iacc[j * NReg + i], vabsa, vsb);
+          }
+          b1ptr += VLen * KTILE / 8;
+        }
+      }
+    } else {
+      for (int ik = 0; ik < blocksize; ik += KTILE) {
+        __m512i va[MReg];
+        for (int i = 0; i < MReg; i++) {
+          va[i] = _mm512_set1_epi32(*(int*)(A.aptr + ib * blocksize + ik + i * A.lda));
+        }
+        for (int i = 0; i < NReg; i++) {
+          auto vb1 = unpack_1bits(b1ptr, zmm_0x00, zmm_0x04);
+          vb1 = _mm512_srli_epi32(vb1, 2);
+          vb1 = _mm512_sub_epi8(vb1, vbias);
+          for (int j = 0; j < MReg; j++) {
+            auto vsb = _mm512_sign_epi8(vb1, va[j]);
+            auto vabsa = _mm512_sign_epi8(va[j], va[j]);
+            iacc[j * NReg + i] = _mm512_dpbusd_epi32(iacc[j * NReg + i], vabsa, vsb);
+          }
           b1ptr += VLen * KTILE / 8;
         }
       }

--- a/bestla/bestla/kernel_wrapper.h
+++ b/bestla/bestla/kernel_wrapper.h
@@ -591,13 +591,12 @@ class DecompressKBlockS1S8 {
   template <BTLA_ISA ISA_T>
   static inline BTLA_CODE forward(utils::bit1x8* b1ptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                   int n_offset, int k_offset, int row, int col, void* tmp, size_t tmpsize) {
-    // #if CompileAVX512F()
-    //     if constexpr (utils::isa_base<ISA_T>::avx512f) {
-    //       return avx512f::decompress_kblock_s2_s8<PackRow, NTILE>(b2ptr, zpptr, dstptr, blocksize, ldzp, n_offset,
-    //       k_offset,
-    //                                                               row, col, (int8_t*)tmp, tmpsize);
-    //     }
-    // #endif
+#if CompileAVX512F()
+    if constexpr (utils::isa_base<ISA_T>::avx512f) {
+      return avx512f::decompress_kblock_s1_s8<PackRow, NTILE>(b1ptr, zpptr, dstptr, blocksize, ldzp, n_offset, k_offset,
+                                                              row, col, (int8_t*)tmp, tmpsize);
+    }
+#endif
 #if CompileAVX2()
     if constexpr (utils::isa_base<ISA_T>::avx2) {
       return avx2::decompress_kblock_s1_s8<PackRow, NTILE>(b1ptr, zpptr, dstptr, blocksize, ldzp, n_offset, k_offset,
@@ -822,15 +821,13 @@ class DecompressKBlockS1Fp {
                                   int8_t* zero_points, int k_offset, int n_offset, int kblock, int NPad, void* tmp,
                                   size_t tmpsize) {
     BTLA_CODE ret = BTLA_CODE::NotSupport;
-    // #if CompileAVX512F()
-    //     if constexpr (utils::isa_base<ISA_T>::avx512f) {
-    //       return avx512f::decompress_kblock_s3_fp<PackRow, NTILE, DstT>(b2ptr, b1ptr, dstptr, row, col, scales,
-    //       sdtype,
-    //                                                                     zero_points, k_offset, n_offset, kblock,
-    //                                                                     NPad, reinterpret_cast<int8_t*>(tmp),
-    //                                                                     tmpsize);
-    //     }
-    // #endif
+#if CompileAVX512F()
+    if constexpr (utils::isa_base<ISA_T>::avx512f) {
+      return avx512f::decompress_kblock_s1_fp<PackRow, NTILE, DstT>(b1ptr, dstptr, row, col, scales, sdtype,
+                                                                    zero_points, k_offset, n_offset, kblock, NPad,
+                                                                    reinterpret_cast<int8_t*>(tmp), tmpsize);
+    }
+#endif
 #if CompileAVX2()
     if constexpr (utils::isa_base<ISA_T>::avx2) {
       return avx2::decompress_kblock_s1_fp<PackRow, NTILE, DstT>(b1ptr, dstptr, row, col, scales, sdtype, zero_points,

--- a/bestla/bestla/kernel_wrapper.h
+++ b/bestla/bestla/kernel_wrapper.h
@@ -1293,19 +1293,17 @@ class GEMVWoqNBits {
       return ref::gemv_7bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
     if (B.nbits == 1) {
-      // #if CompileAVX512VNNI()
-      //       if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
-      //         return avx512f::vnni::gemv_3bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize,
-      //         (int8_t*)tmp,
-      //                                                                         tmpsize);
-      //       }
-      // #endif
-      // #if CompileAVXVNNI()
-      //       if (ISA_T >= BTLA_ISA::AVX_VNNI) {
-      //         return avx2::vnni::gemv_3bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
-      //         tmpsize);
-      //       }
-      // #endif
+#if CompileAVX512VNNI()
+      if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
+        return avx512f::vnni::gemv_1bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
+                                                                        tmpsize);
+      }
+#endif
+#if CompileAVXVNNI()
+      if (ISA_T >= BTLA_ISA::AVX_VNNI) {
+        return avx2::vnni::gemv_1bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+      }
+#endif
 #if CompileAVX2()
       if (ISA_T >= BTLA_ISA::AVX2) {
         return avx2::gemv_1bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
@@ -1404,13 +1402,12 @@ class GEMVWoqNBits {
       return ref::gemv_7bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
     if (B.nbits == 1) {
-      // #if CompileAVX512VNNI()
-      //       if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
-      //         return avx512f::vnni::gemv_5bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize,
-      //         (int8_t*)tmp,
-      //                                                                         tmpsize);
-      //       }
-      // #endif
+#if CompileAVX512VNNI()
+      if (ISA_T >= BTLA_ISA::AVX512_VNNI) {
+        return avx512f::vnni::gemv_1bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
+                                                                        tmpsize);
+      }
+#endif
 #if CompileAVXVNNI()
       if (ISA_T >= BTLA_ISA::AVX_VNNI) {
         return avx2::vnni::gemv_1bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
@@ -1509,13 +1506,12 @@ class GEMVWoqNBits {
       return ref::gemv_7bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
     if (B.nbits == 1) {
-      // #if CompileAVX512F()
-      //       if (ISA_T >= BTLA_ISA::AVX512F) {
-      //         return avx512f::gemv_6bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize,
-      //         (int8_t*)tmp,
-      //                                                                   tmpsize);
-      //       }
-      // #endif
+#if CompileAVX512F()
+      if (ISA_T >= BTLA_ISA::AVX512F) {
+        return avx512f::gemv_1bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp,
+                                                                  tmpsize);
+      }
+#endif
 #if CompileAVX2()
       if (ISA_T >= BTLA_ISA::AVX2) {
         return avx2::gemv_1bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);

--- a/bestla/bestla/kernel_wrapper.h
+++ b/bestla/bestla/kernel_wrapper.h
@@ -1309,12 +1309,11 @@ class GEMVWoqNBits {
       //         tmpsize);
       //       }
       // #endif
-      // #if CompileAVX2()
-      //       if (ISA_T >= BTLA_ISA::AVX2) {
-      //         return avx2::gemv_3bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
-      //         tmpsize);
-      //       }
-      // #endif
+#if CompileAVX2()
+      if (ISA_T >= BTLA_ISA::AVX2) {
+        return avx2::gemv_1bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+      }
+#endif
       return ref::gemv_1bit_u8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
     return BTLA_CODE::NotSupport;
@@ -1415,12 +1414,11 @@ class GEMVWoqNBits {
       //                                                                         tmpsize);
       //       }
       // #endif
-      // #if CompileAVXVNNI()
-      //       if (ISA_T >= BTLA_ISA::AVX_VNNI) {
-      //         return avx2::vnni::gemv_5bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp,
-      //         tmpsize);
-      //       }
-      // #endif
+#if CompileAVXVNNI()
+      if (ISA_T >= BTLA_ISA::AVX_VNNI) {
+        return avx2::vnni::gemv_1bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+      }
+#endif
       return ref::gemv_1bit_s8s8_fp32<ScaleT, NTILE, MTILE>(A, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
     return BTLA_CODE::NotSupport;
@@ -1521,12 +1519,11 @@ class GEMVWoqNBits {
       //                                                                   tmpsize);
       //       }
       // #endif
-      // #if CompileAVX2()
-      //       if (ISA_T >= BTLA_ISA::AVX2) {
-      //         return avx2::gemv_6bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp,
-      //         tmpsize);
-      //       }
-      // #endif
+#if CompileAVX2()
+      if (ISA_T >= BTLA_ISA::AVX2) {
+        return avx2::gemv_1bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
+      }
+#endif
       return ref::gemv_1bit_fp32_fp32<ScaleT, NTILE, MTILE>(A, lda, B, C, ldc, k, blocksize, (int8_t*)tmp, tmpsize);
     }
     return BTLA_CODE::NotSupport;

--- a/bestla/bestla/ut/bestla_benchmark.cpp
+++ b/bestla/bestla/ut/bestla_benchmark.cpp
@@ -441,6 +441,7 @@ class UTWOQ_CompFp32 {
  public:
   UTWOQ_CompFp32() {
     UT_START();
+    ut_s1();
     ut_s7();
     ut_s6();
     /*ut_s5();
@@ -449,6 +450,10 @@ class UTWOQ_CompFp32 {
     ut_s3();*/
     // ut_s8();
     // ut_f4();
+  }
+  void ut_s1() {
+    benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1, 4096, 4096, BTLA_DTYPE::S1_CLIP);
+    benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S1_CLIP);
   }
   void ut_s2() {
     benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1, 4096, 4096, BTLA_DTYPE::S2_CLIP);
@@ -691,6 +696,7 @@ class UTWOQ_CompInt8 {
  public:
   UTWOQ_CompInt8() {
     UT_START();
+    ut_s1();
     ut_s7();
     ut_s6();
     /*ut_s5();
@@ -698,6 +704,13 @@ class UTWOQ_CompInt8 {
     ut_s4();
     ut_s3();*/
     //   ut_s8();
+  }
+  void ut_s1() {
+    benchmark_all<prologue_b::gemm::WeightKBlockNInteger, float>(1, 4096, 4096, BTLA_DTYPE::S1_CLIP, true);
+    benchmark_all<prologue_b::gemm::WeightKBlockNInteger, float>(1, 4096, 4096, BTLA_DTYPE::S1_CLIP);
+    benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1, 4096, 4096, BTLA_DTYPE::S1_CLIP);
+    /*benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::S1_CLIP);
+    benchmark_all<prologue_b::gemm::WeightKBlockNInteger, utils::bf16>(2048, 4096, 4096, BTLA_DTYPE::S1_CLIP);*/
   }
 
   void ut_s2() {

--- a/bestla/bestla/ut/bestla_prologue_b.cpp
+++ b/bestla/bestla/ut/bestla_prologue_b.cpp
@@ -649,15 +649,49 @@ class UT_CompFp32 {
  public:
   UT_CompFp32() {
     UT_START();
+    ut_s7();
     ut_s6();
     ut_s5();
     ut_s4();
     ut_s2();
+    ut_s1();
     ut_s3();
     ut_s8();
 
     ut_f4();
     ut_f8();
+  }
+
+  void ut_s1() {
+    GetCPUDevice();
+    if (_cd->AVX2()) {
+      ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::BF16,
+                                                            false);
+      ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(1, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                            true);
+      ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(8, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                            false);
+      ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, 128, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                            false);
+      ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, 128, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                            true);
+      ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, -1, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                            false);
+    }
+    if (_cd->AVX512F()) {
+      ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::BF16,
+                                                               false);
+      ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(1, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                               true);
+      ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(8, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                               false);
+      ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, 128, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                               false);
+      ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, 128, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                               true);
+      ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, -1, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                               false);
+    }
   }
 
   void ut_s2() {
@@ -827,6 +861,39 @@ class UT_CompFp32 {
                                                              false);
   }
 
+  void ut_s7() {
+    CheckISA(AVX2);
+    ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                          true);
+    ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                          false);
+    ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, 128, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                          false);
+    ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, -1, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                          false);
+    ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::BF16,
+                                                          false);
+    ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                          true);
+    ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                          false);
+    CheckISA(AVX512F);
+    ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                             true);
+    ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                             false);
+    ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, 128, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                             false);
+    ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, -1, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                             false);
+    ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::BF16,
+                                                             false);
+    ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                             true);
+    ut_int<sAVX512F, prologue_b::gemm::WeightKBlockNInteger>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                             false);
+  }
+
   void ut_s8() {
     CheckISA(AVX2);
     ut_int<sAVX2, prologue_b::gemm::WeightKBlockNInteger>(2, 4096, 4096, 32, BTLA_DTYPE::S8, BTLA_DTYPE::BF16, false);
@@ -950,10 +1017,12 @@ class UT_CompInt8 {
  public:
   UT_CompInt8() {
     UT_START();
+    ut_s7();
     ut_s6();
     ut_s5();
     ut_s4();
     ut_s2();
+    ut_s1();
     ut_s3();
   }
 
@@ -992,6 +1061,82 @@ class UT_CompInt8 {
     if (_cd->AMX_INT8()) {
       ut_newkblock<gemm::ICoreRowNAmxint8KBlock<48, 16>>(128, 4096, 4096, 128, BTLA_DTYPE::S2_CLIP, BTLA_DTYPE::F32);
       ut_newkblock<gemm::ICoreRowNAmxint8KBlock<48, 16>>(1, 4096, 4096, 64, BTLA_DTYPE::S2_CLIP, BTLA_DTYPE::F32);
+    }
+  }
+
+  void ut_s1() {
+    GetCPUDevice();
+    if (_cd->AVX2()) {
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 16, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::BF16);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(2, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(8, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(8, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 128, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32);
+    }
+    if (_cd->AVX_VNNI()) {
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(1, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(1, 4096, 4096, 16, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::BF16);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(2, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(8, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(8, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(1, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(1, 4096, 4096, 128, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32);
+    }
+    if (_cd->AVX512_VNNI()) {
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(1, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                           true);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(1, 4096, 4096, 16, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::BF16);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(2, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                           true);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(8, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32,
+                                                           true);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(8, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(1, 4096, 4096, 32, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(1, 4096, 4096, 128, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32);
+    }
+    if (_cd->AMX_INT8()) {
+      ut_newkblock<gemm::ICoreRowNAmxint8KBlock<48, 16>>(128, 4096, 4096, 128, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAmxint8KBlock<48, 16>>(1, 4096, 4096, 64, BTLA_DTYPE::S1_CLIP, BTLA_DTYPE::F32);
+    }
+  }
+
+  void ut_s7() {
+    GetCPUDevice();
+    if (_cd->AVX2()) {
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 16, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::BF16);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(2, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 128, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
+    }
+    if (_cd->AVX_VNNI()) {
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(1, 4096, 4096, 16, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::BF16);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(2, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32, true);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(1, 4096, 4096, 128, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
+    }
+    if (_cd->AVX512_VNNI()) {
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                           true);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(1, 4096, 4096, 16, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::BF16);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(2, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                           true);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32,
+                                                           true);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAvx512vnniKBlock<48, 4>>(1, 4096, 4096, 128, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
+    }
+    if (_cd->AMX_INT8()) {
+      ut_newkblock<gemm::ICoreRowNAmxint8KBlock<48, 16>>(128, 4096, 4096, 128, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
+      ut_newkblock<gemm::ICoreRowNAmxint8KBlock<48, 16>>(1, 4096, 4096, 64, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
     }
   }
 

--- a/bestla/bestla/ut/bestla_prologue_b.cpp
+++ b/bestla/bestla/ut/bestla_prologue_b.cpp
@@ -171,6 +171,9 @@ class UT_BlockQunatize_SN {
   UT_BlockQunatize_SN() {
     UT_START();
     CheckISA(AVX2);
+    ut<sAVX2>(4096, 4096, 32, BTLA_DTYPE::S1_CLIP, true);
+    ut<sAVX2>(4096, 4096, 32, BTLA_DTYPE::S1_CLIP);
+    ut<sAVX2>(4096, 4096, 128, BTLA_DTYPE::S1_CLIP);
     ut<sAVX2>(4096, 4096, 32, BTLA_DTYPE::S7_CLIP, true);
     ut<sAVX2>(4096, 4096, 32, BTLA_DTYPE::S7_CLIP);
     ut<sAVX2>(4096, 4096, 128, BTLA_DTYPE::S7_CLIP);

--- a/bestla/bestla/ut/bestla_prologue_b.cpp
+++ b/bestla/bestla/ut/bestla_prologue_b.cpp
@@ -1104,15 +1104,6 @@ class UT_CompInt8 {
 
   void ut_s7() {
     GetCPUDevice();
-    if (_cd->AVX2()) {
-      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32, true);
-      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 16, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::BF16);
-      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(2, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32, true);
-      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32, true);
-      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(8, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
-      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
-      ut_newkblock<gemm::ICoreRowNAvx2vnniKBlock<24, 2>>(1, 4096, 4096, 128, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32);
-    }
     if (_cd->AVX_VNNI()) {
       ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(1, 4096, 4096, 32, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::F32, true);
       ut_newkblock<gemm::ICoreRowNAvxvnniKBlock<24, 2>>(1, 4096, 4096, 16, BTLA_DTYPE::S7_CLIP, BTLA_DTYPE::BF16);

--- a/bestla/bestla/ut/bestla_ut.h
+++ b/bestla/bestla/ut/bestla_ut.h
@@ -88,6 +88,7 @@ static int8_t cache[CacheSize];
 #define INT4_ERR 3.5f
 #define INT3_ERR 7.f
 #define INT2_ERR 18.f
+#define INT1_ERR 1e3f
 #define FP4_ERR 3.5f
 
 static inline float get_ut_err(BTLA_DTYPE qtype) {
@@ -102,6 +103,8 @@ static inline float get_ut_err(BTLA_DTYPE qtype) {
       err = INT3_ERR;
     } else if (dbits == 2) {
       err = INT2_ERR;
+    } else if (dbits == 1) {
+      err = INT1_ERR;
     } else {
       err = INT4_ERR;
     }

--- a/bestla/bestla/ut/kernel_intrin.cpp
+++ b/bestla/bestla/ut/kernel_intrin.cpp
@@ -57,7 +57,8 @@ class UT_avx512_decompress_s1_s8 {
     }
 
     kernel::avx512f::decompress_kblock_s1_s8<PackRow, NTILE>(s1_wei.data(), isasym ? zp.data() : nullptr, rev.data(),
-                                                          blocksize, NTILE, 0, 0, row_offset, NTILE, cache, CacheSize);
+                                                             blocksize, NTILE, 0, 0, row_offset, NTILE, cache,
+                                                             CacheSize);
     kernel::avx512f::decompress_kblock_s1_s8<PackRow, NTILE>(
         s1_wei.data() + row_offset * NTILE / 8, isasym ? zp.data() : nullptr, rev.data() + row_offset * NTILE,
         blocksize, NTILE, 0, row_offset, row - row_offset, NTILE, cache, CacheSize);
@@ -610,7 +611,6 @@ class UT_avx512_gemv {
     ut_1bit_s8s8<4>(48, 128, 32, true);
     ut_1bit_s8s8<4>(48, 128, 32, false);
 
-
     ut_4bit<1>(48, 128, 32, true);
     ut_4bit<1>(48, 128, 32, false);
     ut_4bit<4>(48, 128, 32, false);
@@ -705,7 +705,8 @@ class UT_avx512_gemv {
     gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
     utils::GemvParamB<float> B{nullptr, nullptr, (uint8_t*)b1.data(), scaleb.data(), iasym ? bzp.data() : nullptr,
                                1,       n};
-    kernel::avx512f::gemv_1bit_fp32_fp32<float, 48, MTILE>(Af32.data(), k, B, Cf32.data(), n, k, kblock, cache, CacheSize);
+    kernel::avx512f::gemv_1bit_fp32_fp32<float, 48, MTILE>(Af32.data(), k, B, Cf32.data(), n, k, kblock, cache,
+                                                           CacheSize);
     buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
   }
 
@@ -755,7 +756,7 @@ class UT_avx512_gemv {
     utils::GemvParamB<float> B{nullptr, nullptr, (uint8_t*)b1.data(), scaleb.data(), iasym ? bzp.data() : nullptr,
                                2,       n};
     kernel::avx512f::vnni::gemv_1bit_u8s8_fp32<float, 48, MTILE>({A.data(), scalea.data(), azp.data(), k, blks}, B,
-                                                              Cf32.data(), n, k, kblock, cache, CacheSize);
+                                                                 Cf32.data(), n, k, kblock, cache, CacheSize);
     buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
   }
 
@@ -803,8 +804,8 @@ class UT_avx512_gemv {
     gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
     utils::GemvParamB<float> B{nullptr, nullptr, (uint8_t*)b1.data(), scaleb.data(), iasym ? bzp.data() : nullptr,
                                2,       n};
-    kernel::avx512f::vnni::gemv_1bit_s8s8_fp32<float, 48, MTILE>({(uint8_t*)A.data(), scalea.data(), nullptr, k, blks}, B,
-                                                              Cf32.data(), n, k, kblock, cache, CacheSize);
+    kernel::avx512f::vnni::gemv_1bit_s8s8_fp32<float, 48, MTILE>({(uint8_t*)A.data(), scalea.data(), nullptr, k, blks},
+                                                                 B, Cf32.data(), n, k, kblock, cache, CacheSize);
     buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
   }
 

--- a/bestla/bestla/ut/kernel_intrin.cpp
+++ b/bestla/bestla/ut/kernel_intrin.cpp
@@ -6,6 +6,68 @@ using namespace utils;
 namespace ut {
 
 #if CompileAVX512F()
+class UT_avx512_decompress_s1_s8 {
+ public:
+  UT_avx512_decompress_s1_s8() {
+    UT_START();
+    CheckISA(AVX512F);
+    ut<1, 48>(32);
+    ut<4, 48>(32);
+    ut<1, 48>(32, true);
+    ut<2, 48>(32, true);
+    ut<4, 48>(32, true);
+  }
+
+  template <int PackRow, int NTILE>
+  void ut(int blocksize, bool isasym = false) {
+    int row = blocksize * 2;
+    int constexpr col = NTILE;
+    printf("Test Case %s: %d %d %d\n", __FUNCTION__, row, col, blocksize);
+    avector<utils::bit1x8> s1_wei(row * col / 8);
+
+    std::vector<int8_t> s8_wei(col * row);
+    std::vector<int8_t> s8_ref(col * row);
+    int blks = row / blocksize;
+    int row_offset = 8;
+    assert(blocksize % 8 == 0);
+    std::vector<int8_t> zp(col * blks);
+    fill_buffer_randn(zp.data(), zp.size(), int8_t(-1), int8_t(0));
+    std::vector<int8_t> rev(col * row);
+    fill_buffer_randn(s8_wei.data(), s8_wei.size(), int8_t(-1), int8_t(0));
+
+    for (int i = 0; i < col * row; i += 8) {
+      memcpy(&s8_ref[i], &s8_wei[i], 8 * sizeof(int8_t));
+      s1_wei[i / 8].a = s8_wei[i + 0] + 1;
+      s1_wei[i / 8].b = s8_wei[i + 1] + 1;
+      s1_wei[i / 8].c = s8_wei[i + 2] + 1;
+      s1_wei[i / 8].d = s8_wei[i + 3] + 1;
+      s1_wei[i / 8].e = s8_wei[i + 4] + 1;
+      s1_wei[i / 8].f = s8_wei[i + 5] + 1;
+      s1_wei[i / 8].g = s8_wei[i + 6] + 1;
+      s1_wei[i / 8].h = s8_wei[i + 7] + 1;
+    }
+    if (isasym) {
+      for (int i = 0; i < row; i += PackRow) {
+        for (int j = 0; j < NTILE; j++) {
+          for (int ip = 0; ip < PackRow; ip++) {
+            s8_ref[i * NTILE + j * PackRow + ip] -= zp[i / blocksize * NTILE + j];
+          }
+        }
+      }
+    }
+
+    kernel::avx512f::decompress_kblock_s1_s8<PackRow, NTILE>(s1_wei.data(), isasym ? zp.data() : nullptr, rev.data(),
+                                                          blocksize, NTILE, 0, 0, row_offset, NTILE, cache, CacheSize);
+    kernel::avx512f::decompress_kblock_s1_s8<PackRow, NTILE>(
+        s1_wei.data() + row_offset * NTILE / 8, isasym ? zp.data() : nullptr, rev.data() + row_offset * NTILE,
+        blocksize, NTILE, 0, row_offset, row - row_offset, NTILE, cache, CacheSize);
+    ut::buffer_error(s8_ref.data(), rev.data(), rev.size(), int8_t(0));
+  }
+};
+#ifdef BTLA_UT_KERNEL_INTRIN
+#endif
+static UT_avx512_decompress_s1_s8 sUT_avx512_decompress_s1_s8;
+
 class UT_avx512_decompress_s4_s8 {
  public:
   UT_avx512_decompress_s4_s8() {
@@ -1830,7 +1892,7 @@ class UT_avx2_decompress_s1_s8 {
     int row_offset = 8;
     assert(blocksize % 8 == 0);
     std::vector<int8_t> zp(col * blks);
-    fill_buffer_randn(zp.data(), zp.size(), int8_t(-4), int8_t(3));
+    fill_buffer_randn(zp.data(), zp.size(), int8_t(-1), int8_t(0));
     std::vector<int8_t> rev(col * row);
     fill_buffer_randn(s8_wei.data(), s8_wei.size(), int8_t(-1), int8_t(0));
 

--- a/bestla/bestla/ut/kernel_intrin.cpp
+++ b/bestla/bestla/ut/kernel_intrin.cpp
@@ -564,6 +564,11 @@ class UT_avx512_gemv {
   UT_avx512_gemv() {
     UT_START();
     CheckISA(AVX512F);
+    ut_1bit_fp32<1>(48, 128, 32, true);
+    ut_1bit_fp32<1>(48, 128, 32, false);
+    ut_1bit_fp32<4>(48, 128, 32, true);
+    ut_1bit_fp32<4>(48, 128, 32, false);
+
     ut_7bit_fp32<1>(48, 128, 32, true);
     ut_7bit_fp32<1>(48, 128, 32, false);
     ut_7bit_fp32<4>(48, 128, 32, true);
@@ -595,6 +600,17 @@ class UT_avx512_gemv {
     ut_2bit_fp32<4>(48, 128, 32, false);
 
     CheckISA(AVX512_VNNI);
+    ut_1bit_u8s8<1>(48, 128, 32, true);
+    ut_1bit_u8s8<1>(48, 128, 32, false);
+    ut_1bit_u8s8<4>(48, 128, 32, true);
+    ut_1bit_u8s8<4>(48, 128, 32, false);
+
+    ut_1bit_s8s8<1>(48, 128, 32, true);
+    ut_1bit_s8s8<1>(48, 128, 32, false);
+    ut_1bit_s8s8<4>(48, 128, 32, true);
+    ut_1bit_s8s8<4>(48, 128, 32, false);
+
+
     ut_4bit<1>(48, 128, 32, true);
     ut_4bit<1>(48, 128, 32, false);
     ut_4bit<4>(48, 128, 32, false);
@@ -654,6 +670,142 @@ class UT_avx512_gemv {
     ut_7bit_u8s8<1>(48, 128, 32, false);
     ut_7bit_u8s8<4>(48, 128, 32, true);
     ut_7bit_u8s8<4>(48, 128, 32, false);
+  }
+
+  template <int MTILE>
+  void ut_1bit_fp32(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit1x8> b1(n * k / 8);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(Af32.data(), Af32.size(), -0.5f, 0.5f);
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-1), int8_t(0));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s1_s8(b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 1) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 4) {
+        if (iasym) {
+          Bf32[(i)*n + j + 0] = (b8[(i)*n + j + 0] - bzp[bid * n + j + 0]) * scaleb[bid * n + j + 0];
+          Bf32[(i)*n + j + 1] = (b8[(i)*n + j + 1] - bzp[bid * n + j + 1]) * scaleb[bid * n + j + 1];
+          Bf32[(i)*n + j + 2] = (b8[(i)*n + j + 2] - bzp[bid * n + j + 2]) * scaleb[bid * n + j + 2];
+          Bf32[(i)*n + j + 3] = (b8[(i)*n + j + 3] - bzp[bid * n + j + 3]) * scaleb[bid * n + j + 3];
+        } else {
+          Bf32[(i)*n + j + 0] = (b8[(i)*n + j + 0]) * scaleb[bid * n + j + 0];
+          Bf32[(i)*n + j + 1] = (b8[(i)*n + j + 1]) * scaleb[bid * n + j + 1];
+          Bf32[(i)*n + j + 2] = (b8[(i)*n + j + 2]) * scaleb[bid * n + j + 2];
+          Bf32[(i)*n + j + 3] = (b8[(i)*n + j + 3]) * scaleb[bid * n + j + 3];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{nullptr, nullptr, (uint8_t*)b1.data(), scaleb.data(), iasym ? bzp.data() : nullptr,
+                               1,       n};
+    kernel::avx512f::gemv_1bit_fp32_fp32<float, 48, MTILE>(Af32.data(), k, B, Cf32.data(), n, k, kblock, cache, CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
+  }
+
+  template <int MTILE>
+  void ut_1bit_u8s8(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit1x8> b1(n * k / 8);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-1), int8_t(0));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<uint8_t> A(MTILE * k), azp(MTILE * blks);
+    fill_buffer_randn(A.data(), A.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(azp.data(), azp.size(), uint8_t(100), uint8_t(150));
+    fill_buffer_randn(scalea.data(), scalea.size(), 0.01f, 0.02f);
+    for (int im = 0; im < MTILE; im++) {
+      for (int i = 0; i < k; i += 4) {
+        int bid = i / kblock + im * blks;
+        for (int j = 0; j < 4; j++) {
+          Af32[im * k + i + j] = (int(A[im * k + i + j]) - azp[bid]) * scalea[bid];
+        }
+      }
+    }
+
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s1_s8(b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 4) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 1) {
+        if (iasym) {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+        } else {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0])) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1])) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2])) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3])) * scaleb[bid * n + j];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{nullptr, nullptr, (uint8_t*)b1.data(), scaleb.data(), iasym ? bzp.data() : nullptr,
+                               2,       n};
+    kernel::avx512f::vnni::gemv_1bit_u8s8_fp32<float, 48, MTILE>({A.data(), scalea.data(), azp.data(), k, blks}, B,
+                                                              Cf32.data(), n, k, kblock, cache, CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
+  }
+
+  template <int MTILE>
+  void ut_1bit_s8s8(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit1x8> b1(n * k / 8);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-1), int8_t(0));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<int8_t> A(MTILE * k);
+    fill_buffer_randn(A.data(), A.size(), int8_t(0), int8_t(127));
+    fill_buffer_randn(scalea.data(), scalea.size(), 0.01f, 0.02f);
+    for (int im = 0; im < MTILE; im++) {
+      for (int i = 0; i < k; i += 4) {
+        int bid = i / kblock + im * blks;
+        for (int j = 0; j < 4; j++) {
+          Af32[im * k + i + j] = (int(A[im * k + i + j])) * scalea[bid];
+        }
+      }
+    }
+
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s1_s8(b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 4) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 1) {
+        if (iasym) {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+        } else {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0])) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1])) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2])) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3])) * scaleb[bid * n + j];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{nullptr, nullptr, (uint8_t*)b1.data(), scaleb.data(), iasym ? bzp.data() : nullptr,
+                               2,       n};
+    kernel::avx512f::vnni::gemv_1bit_s8s8_fp32<float, 48, MTILE>({(uint8_t*)A.data(), scalea.data(), nullptr, k, blks}, B,
+                                                              Cf32.data(), n, k, kblock, cache, CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
   }
 
   template <int MTILE>

--- a/bestla/bestla/ut/kernel_intrin.cpp
+++ b/bestla/bestla/ut/kernel_intrin.cpp
@@ -1805,6 +1805,68 @@ class UT_avx2_decompress_s3_s8 {
 static UT_avx2_decompress_s3_s8 sUT_avx2_decompress_s3_s8;
 #endif
 
+class UT_avx2_decompress_s1_s8 {
+ public:
+  UT_avx2_decompress_s1_s8() {
+    UT_START();
+    CheckISA(AVX2);
+    ut<1, 24>(32);
+    ut<4, 24>(32);
+    ut<1, 24>(32, true);
+    ut<2, 24>(32, true);
+    ut<4, 24>(32, true);
+  }
+
+  template <int PackRow, int NTILE>
+  void ut(int blocksize, bool isasym = false) {
+    int row = blocksize * 2;
+    int constexpr col = NTILE;
+    printf("Test Case %s: %d %d %d\n", __FUNCTION__, row, col, blocksize);
+    avector<utils::bit1x8> s1_wei(row * col / 8);
+
+    std::vector<int8_t> s8_wei(col * row);
+    std::vector<int8_t> s8_ref(col * row);
+    int blks = row / blocksize;
+    int row_offset = 8;
+    assert(blocksize % 8 == 0);
+    std::vector<int8_t> zp(col * blks);
+    fill_buffer_randn(zp.data(), zp.size(), int8_t(-4), int8_t(3));
+    std::vector<int8_t> rev(col * row);
+    fill_buffer_randn(s8_wei.data(), s8_wei.size(), int8_t(-1), int8_t(0));
+
+    for (int i = 0; i < col * row; i += 8) {
+      memcpy(&s8_ref[i], &s8_wei[i], 8 * sizeof(int8_t));
+      s1_wei[i / 8].a = s8_wei[i + 0] + 1;
+      s1_wei[i / 8].b = s8_wei[i + 1] + 1;
+      s1_wei[i / 8].c = s8_wei[i + 2] + 1;
+      s1_wei[i / 8].d = s8_wei[i + 3] + 1;
+      s1_wei[i / 8].e = s8_wei[i + 4] + 1;
+      s1_wei[i / 8].f = s8_wei[i + 5] + 1;
+      s1_wei[i / 8].g = s8_wei[i + 6] + 1;
+      s1_wei[i / 8].h = s8_wei[i + 7] + 1;
+    }
+    if (isasym) {
+      for (int i = 0; i < row; i += PackRow) {
+        for (int j = 0; j < NTILE; j++) {
+          for (int ip = 0; ip < PackRow; ip++) {
+            s8_ref[i * NTILE + j * PackRow + ip] -= zp[i / blocksize * NTILE + j];
+          }
+        }
+      }
+    }
+
+    kernel::avx2::decompress_kblock_s1_s8<PackRow, NTILE>(s1_wei.data(), isasym ? zp.data() : nullptr, rev.data(),
+                                                          blocksize, NTILE, 0, 0, row_offset, NTILE, cache, CacheSize);
+    kernel::avx2::decompress_kblock_s1_s8<PackRow, NTILE>(
+        s1_wei.data() + row_offset * NTILE / 8, isasym ? zp.data() : nullptr, rev.data() + row_offset * NTILE,
+        blocksize, NTILE, 0, row_offset, row - row_offset, NTILE, cache, CacheSize);
+    ut::buffer_error(s8_ref.data(), rev.data(), rev.size(), int8_t(0));
+  }
+};
+#ifdef BTLA_UT_KERNEL_INTRIN
+static UT_avx2_decompress_s1_s8 sUT_avx2_decompress_s1_s8;
+#endif
+
 class UT_avx2_decompress_s2_s8 {
  public:
   UT_avx2_decompress_s2_s8() {
@@ -1950,6 +2012,11 @@ class UT_avx2_gemv {
   UT_avx2_gemv() {
     UT_START();
     CheckISA(AVX2);
+    ut_1bit_fp32<1>(24, 128, 32, true);
+    ut_1bit_fp32<1>(24, 128, 32, false);
+    ut_1bit_fp32<4>(24, 128, 32, true);
+    ut_1bit_fp32<4>(24, 128, 32, false);
+
     ut_7bit_fp32<1>(24, 128, 32, true);
     ut_7bit_fp32<1>(24, 128, 32, false);
     ut_7bit_fp32<4>(24, 128, 32, true);
@@ -1981,6 +2048,16 @@ class UT_avx2_gemv {
     ut_2bit_fp32<4>(24, 128, 32, false);
 
     CheckISA(AVX_VNNI);
+    ut_1bit_u8s8<1>(24, 128, 32, true);
+    ut_1bit_u8s8<1>(24, 128, 32, false);
+    ut_1bit_u8s8<4>(24, 128, 32, true);
+    ut_1bit_u8s8<4>(24, 128, 32, false);
+
+    ut_1bit_s8s8<1>(24, 128, 32, true);
+    ut_1bit_s8s8<1>(24, 128, 32, false);
+    ut_1bit_s8s8<4>(24, 128, 32, true);
+    ut_1bit_s8s8<4>(24, 128, 32, false);
+
     ut_7bit_u8s8<1>(24, 128, 32, true);
     ut_7bit_u8s8<1>(24, 128, 32, false);
     ut_7bit_u8s8<4>(24, 128, 32, true);
@@ -2336,6 +2413,142 @@ class UT_avx2_gemv {
     utils::GemvParamB<float> B{
         nullptr, (uint8_t*)b2.data(), (uint8_t*)b1.data(), scaleb.data(), iasym ? bzp.data() : nullptr, 2, n};
     kernel::avx2::gemv_3bit_fp32_fp32<float, 24, MTILE>(Af32.data(), k, B, Cf32.data(), n, k, kblock, cache, CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
+  }
+
+  template <int MTILE>
+  void ut_1bit_fp32(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit1x8> b1(n * k / 8);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(Af32.data(), Af32.size(), -0.5f, 0.5f);
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-1), int8_t(0));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s1_s8(b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 1) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 4) {
+        if (iasym) {
+          Bf32[(i)*n + j + 0] = (b8[(i)*n + j + 0] - bzp[bid * n + j + 0]) * scaleb[bid * n + j + 0];
+          Bf32[(i)*n + j + 1] = (b8[(i)*n + j + 1] - bzp[bid * n + j + 1]) * scaleb[bid * n + j + 1];
+          Bf32[(i)*n + j + 2] = (b8[(i)*n + j + 2] - bzp[bid * n + j + 2]) * scaleb[bid * n + j + 2];
+          Bf32[(i)*n + j + 3] = (b8[(i)*n + j + 3] - bzp[bid * n + j + 3]) * scaleb[bid * n + j + 3];
+        } else {
+          Bf32[(i)*n + j + 0] = (b8[(i)*n + j + 0]) * scaleb[bid * n + j + 0];
+          Bf32[(i)*n + j + 1] = (b8[(i)*n + j + 1]) * scaleb[bid * n + j + 1];
+          Bf32[(i)*n + j + 2] = (b8[(i)*n + j + 2]) * scaleb[bid * n + j + 2];
+          Bf32[(i)*n + j + 3] = (b8[(i)*n + j + 3]) * scaleb[bid * n + j + 3];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{nullptr, nullptr, (uint8_t*)b1.data(), scaleb.data(), iasym ? bzp.data() : nullptr,
+                               1,       n};
+    kernel::avx2::gemv_1bit_fp32_fp32<float, 24, MTILE>(Af32.data(), k, B, Cf32.data(), n, k, kblock, cache, CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
+  }
+
+  template <int MTILE>
+  void ut_1bit_u8s8(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit1x8> b1(n * k / 8);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-1), int8_t(0));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<uint8_t> A(MTILE * k), azp(MTILE * blks);
+    fill_buffer_randn(A.data(), A.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(azp.data(), azp.size(), uint8_t(100), uint8_t(150));
+    fill_buffer_randn(scalea.data(), scalea.size(), 0.01f, 0.02f);
+    for (int im = 0; im < MTILE; im++) {
+      for (int i = 0; i < k; i += 4) {
+        int bid = i / kblock + im * blks;
+        for (int j = 0; j < 4; j++) {
+          Af32[im * k + i + j] = (int(A[im * k + i + j]) - azp[bid]) * scalea[bid];
+        }
+      }
+    }
+
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s1_s8(b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 4) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 1) {
+        if (iasym) {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+        } else {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0])) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1])) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2])) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3])) * scaleb[bid * n + j];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{nullptr, nullptr, (uint8_t*)b1.data(), scaleb.data(), iasym ? bzp.data() : nullptr,
+                               2,       n};
+    kernel::avx2::vnni::gemv_1bit_u8s8_fp32<float, 24, MTILE>({A.data(), scalea.data(), azp.data(), k, blks}, B,
+                                                              Cf32.data(), n, k, kblock, cache, CacheSize);
+    buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
+  }
+
+  template <int MTILE>
+  void ut_1bit_s8s8(int n, int k, int kblock, bool iasym) {
+    printf("Test Case %s_%d: %d %d %d Asym:%d\n", __FUNCTION__, MTILE, n, k, kblock, iasym);
+    int blks = k / kblock;
+    avector<bit1x8> b1(n * k / 8);
+    avector<float> scaleb(n * blks), scalea(MTILE * blks);
+    avector<int8_t> bzp(n * blks);
+    avector<float> Af32(MTILE * k), Bf32(n * k), Cf32(MTILE * n), Cref(MTILE * n);
+    fill_buffer_randn((uint8_t*)b1.data(), b1.size(), uint8_t(0), uint8_t(255));
+    fill_buffer_randn(bzp.data(), bzp.size(), int8_t(-1), int8_t(0));
+    fill_buffer_randn(scaleb.data(), scaleb.size(), 0.01f, 0.02f);
+    avector<int8_t> A(MTILE * k);
+    fill_buffer_randn(A.data(), A.size(), int8_t(0), int8_t(127));
+    fill_buffer_randn(scalea.data(), scalea.size(), 0.01f, 0.02f);
+    for (int im = 0; im < MTILE; im++) {
+      for (int i = 0; i < k; i += 4) {
+        int bid = i / kblock + im * blks;
+        for (int j = 0; j < 4; j++) {
+          Af32[im * k + i + j] = (int(A[im * k + i + j])) * scalea[bid];
+        }
+      }
+    }
+
+    avector<int8_t> b8(n * k);
+    kernel::ref::decompress_s1_s8(b1.data(), b8.data(), b8.size(), cache, CacheSize);
+    for (int i = 0; i < k; i += 4) {
+      int bid = i / kblock;
+      for (int j = 0; j < n; j += 1) {
+        if (iasym) {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3]) - bzp[bid * n + j]) * scaleb[bid * n + j];
+        } else {
+          Bf32[(i + 0) * n + j] = (int(b8[i * n + j * 4 + 0])) * scaleb[bid * n + j];
+          Bf32[(i + 1) * n + j] = (int(b8[i * n + j * 4 + 1])) * scaleb[bid * n + j];
+          Bf32[(i + 2) * n + j] = (int(b8[i * n + j * 4 + 2])) * scaleb[bid * n + j];
+          Bf32[(i + 3) * n + j] = (int(b8[i * n + j * 4 + 3])) * scaleb[bid * n + j];
+        }
+      }
+    }
+    gemmref_fp32fp32fp32(MTILE, n, k, Af32.data(), Bf32.data(), Cref.data(), k, n, n);
+    utils::GemvParamB<float> B{nullptr, nullptr, (uint8_t*)b1.data(), scaleb.data(), iasym ? bzp.data() : nullptr,
+                               2,       n};
+    kernel::avx2::vnni::gemv_1bit_s8s8_fp32<float, 24, MTILE>({(uint8_t*)A.data(), scalea.data(), nullptr, k, blks}, B,
+                                                              Cf32.data(), n, k, kblock, cache, CacheSize);
     buffer_error(Cref.data(), Cf32.data(), Cref.size(), FP32_ERR);
   }
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -6,7 +6,7 @@ Argument description of run.py ([supported MatMul combinations](#supported-matri
 | Argument                    | Description                                                                                                   |
 | --------------              | ---------------------------------------------------------------------                                         |
 | model                       | Directory containing model file or model id: String                                                           |
-| --weight_dtype              | Data type of quantized weight: int4/int3/int2/int5/int6/int7/int8/fp8(=fp8_e4m3)/fp8_e5m2/fp4(=fp4e2m1)/nf4 (default int4)                                                       |
+| --weight_dtype              | Data type of quantized weight: int4/int3/int2/int5/int6/int7/int1/int8/fp8(=fp8_e4m3)/fp8_e5m2/fp4(=fp4e2m1)/nf4 (default int4)                                                       |
 | --alg                       | Quantization algorithm: sym/asym (default sym)                                                                |
 | --group_size                | Group size: Int, 16/32/64/128/-1 (per channel) (default: 32)                                                                                 |
 | --scale_dtype               | Data type of scales: fp32/bf16/fp8 (default fp32)                                                                 |
@@ -60,7 +60,7 @@ Argument description of quantize.py ([supported MatMul combinations](#supported-
 | --build_dir     | Path to the build file: String                               |
 | --config        | Path to the configuration file: String (default: "")         |
 | --nthread       | Number of threads to use: Int (default: 1)                   |
-| --weight_dtype  | Data type of quantized weight: int4/int3/int2/int5/int6/int7/int8/fp8(=fp8_e4m3)/fp8_e5m2/fp4(=fp4_e2m1)/nf4 (default: int4)     |
+| --weight_dtype  | Data type of quantized weight: int4/int3/int2/int5/int6/int7/int1/int8/fp8(=fp8_e4m3)/fp8_e5m2/fp4(=fp4_e2m1)/nf4 (default: int4)     |
 | --alg           | Quantization algorithm to use: sym/asym (default: sym)       |
 | --group_size    | Group size: Int 16/32/64/128/-1 (per channel) (default: 32)                                |
 | --scale_dtype   | Data type of scales: bf16/fp32/fp8 (default: fp32)               |
@@ -69,7 +69,7 @@ Argument description of quantize.py ([supported MatMul combinations](#supported-
 
 #### Supported Matrix Multiplication Data Types Combinations
 
-Our Neural Speed supports  INT4 / INT3 / INT2 / INT5 / INT6 / INT7 / INT8 / FP8 (E4M3, E5M2) / FP4 (E2M1) / NF4 weight-only quantization and FP32 / FP16 / BF16 / INT8 computation forward matmul on the Intel platforms. Here are the all supported data types combinations for matmul operations (quantization and forward).
+Our Neural Speed supports  INT4 / INT3 / INT2 / INT5 / INT6 / INT7 / INT1 / INT8 / FP8 (E4M3, E5M2) / FP4 (E2M1) / NF4 weight-only quantization and FP32 / FP16 / BF16 / INT8 computation forward matmul on the Intel platforms. Here are the all supported data types combinations for matmul operations (quantization and forward).
 > This table will be updated frequently due to active development. For details you can refer to [BesTLA](../bestla#weight-only)
 
 | Weight dtype | Compute dtype (default value) | Scale dtype (default value) | Quantization scheme (default value) |
@@ -82,6 +82,7 @@ Our Neural Speed supports  INT4 / INT3 / INT2 / INT5 / INT6 / INT7 / INT8 / FP8 
 | INT5 | INT8 / BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym / asym (sym) |
 | INT6 | INT8 / BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym / asym (sym) |
 | INT7 | INT8 / BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym / asym (sym) |
+| INT1 | INT8 / BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym / asym (sym) |
 | FP8 (E4M3, E5M2) | BF16 / FP16 / FP32 (FP32) | FP8 (FP8) | sym (sym) |
 | FP4 (E2M1) | BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym (sym) |
 | NF4 | BF16 / FP16 / FP32 (FP32) | BF16 / FP32 (FP32) | sym (sym) |

--- a/neural_speed/core/README.md
+++ b/neural_speed/core/README.md
@@ -27,6 +27,7 @@ int2 | symmetric or asymmetric | multiplier of 8, -1<sup>1</sup>
 int5 | symmetric or asymmetric | multiplier of 8, -1<sup>1</sup>
 int6 | symmetric or asymmetric | multiplier of 8, -1<sup>1</sup>
 int7 | symmetric or asymmetric<sup>2</sup> | multiplier of 8, -1<sup>1</sup>
+int1 | symmetric or asymmetric | multiplier of 8, -1<sup>1</sup>
 int8 | symmetric | multiplier of 8, -1<sup>1</sup>
 fp4 | | multiplier of 8
 nf4 | | multiplier of 8
@@ -84,7 +85,10 @@ Skylake |  sym int3<br>group size=128<br>compute type=fp32 | AVX512F
 Alder Lake (12th Gen)<br>Raptor Lake (13th and 14th Gen)| sym int3<br>group size=128<br>compute type=int8 | AVX_VNNI
 Older architecture (before 12th Gen)|  sym int3<br>group size=128<br>compute type=int8 | AVX2
 
+`sym int5 group=-1 comp_dtype=int8` is the fastest configuration for the first-token with good accuracy.  
+`sym int3 group=128 comp_dtype=int8` is the fastest configuration for the next-token with good accuracy.
+
 NOTE:  
-1. group_size=-1 requires the INC's finetuned model, or it may have lower accuracy than small group sizes. It has the smallest model size, and the fastest first-token performance.
+1. group_size=-1 has the smallest model size, and the fastest first-token performance. But it requires the INC's finetuned model, or it may have lower accuracy than small group sizes. It 
 2. group_size=128 is a balance of accuracy and speed if you want RTN quantization only.
 3. group_size=32, scale_dtype=bf16, compute_dtype=int8, alg=sym equals llama.cpp's Q4_0.

--- a/neural_speed/core/README.md
+++ b/neural_speed/core/README.md
@@ -32,12 +32,12 @@ int8 | symmetric | multiplier of 8, -1<sup>1</sup>
 fp4 | | multiplier of 8
 nf4 | | multiplier of 8
 
-<sup>1</sup>: group size=-1 means per channel quantization on output channel (or group size equals to input channel size).
+<sup>1</sup>: group size=-1 means per channel quantization on output channel (or group size equals to input channel size).  
 <sup>2</sup>: int7 + asymmetric may cause numeric overflow if the device only has AVX2 without AVX_VNNI.
 
 NOTE:
 1. AMX_INT8 requires group size is aligend to 128 (best hardware efficiency)
-2. int3 and int2 have accuracy loss.
+2. int1, int2 and int3 have accuracy loss using RTN quantization.
 
 ### Hybrid quantization support
 We can support the hybrid quantization combination. E.g. int4 x int2 mixed quantization.   

--- a/neural_speed/core/README.md
+++ b/neural_speed/core/README.md
@@ -85,10 +85,10 @@ Skylake |  sym int3<br>group size=128<br>compute type=fp32 | AVX512F
 Alder Lake (12th Gen)<br>Raptor Lake (13th and 14th Gen)| sym int3<br>group size=128<br>compute type=int8 | AVX_VNNI
 Older architecture (before 12th Gen)|  sym int3<br>group size=128<br>compute type=int8 | AVX2
 
-`sym int5 group=-1 comp_dtype=int8` is the fastest configuration for the first-token with good accuracy.  
-`sym int3 group=128 comp_dtype=int8` is the fastest configuration for the next-token with good accuracy.
+`sym int5 group=-1 comp_dtype=int8` is the fastest configuration for the first-token with good accuracy (validated with LLaMa2-7B).  
+`sym int3 group=128 comp_dtype=int8` is the fastest configuration for the next-token with good accuracy (validated with LLaMa2-7B).
 
 NOTE:  
-1. group_size=-1 has the smallest model size, and the fastest first-token performance. But it requires the INC's finetuned model, or it may have lower accuracy than small group sizes. It 
+1. group_size=-1 has the smallest model size, and the best performance. But it requires the INC's finetuned model, or it may have lower accuracy than small group sizes.
 2. group_size=128 is a balance of accuracy and speed if you want RTN quantization only.
 3. group_size=32, scale_dtype=bf16, compute_dtype=int8, alg=sym equals llama.cpp's Q4_0.

--- a/neural_speed/models/model_utils/quant_utils.cpp
+++ b/neural_speed/models/model_utils/quant_utils.cpp
@@ -339,10 +339,6 @@ size_t bestla_quantize(const float* f32ptr, void* dstpr, const quant_params_inte
     }
     scale_type = BTLA_DTYPE::F8_E8M0;
   }
-  if (quant_type == BTLA_DTYPE::S1_CLIP) {
-    printf("Current not support this data type, reset to int4\n");
-    quant_type = BTLA_DTYPE::S4_CLIP;
-  }
   auto gsize = params.group_size == -1 ? k : params.group_size;
   auto size = BTLAGemmPackBSize(n, k, gsize, quant_type, scale_type, params.alg == quant_alg::asym, ctype, nullptr);
   bool constexpr IsTrans_TorchWeight = true;


### PR DESCRIPTION
## Type of Change

support new weight_dtype=int1

LLaMa2-7B
weight_dtype=int1, group_size=128, alg=sym, scale_dtype=bf16, comp_dtype=int8:
```
 Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun Хронологија Хронологија Хронологија Хронологија Хронологија Хронологија Хронологија Хронологија Хронологија Хронологија Хронологија Хронологија Хронологија Хронологија Хронологија Хронологија
model_print_timings:        load time =   180.49 ms
model_print_timings:      sample time =     3.36 ms /    16 runs   (    0.21 ms per token)
model_print_timings: prompt eval time =   169.91 ms /    33 tokens (    5.15 ms per token)
model_print_timings:        eval time =   293.41 ms /    15 runs   (   19.56 ms per token)
model_print_timings:       total time =   484.67 ms
========== eval time log of each prediction ==========
prediction   0, time: 169.91ms
prediction   1, time: 19.45ms
prediction   2, time: 19.28ms
prediction   3, time: 19.17ms
prediction   4, time: 19.27ms
```
weight_dtype=int1, group_size=128, alg=asym, scale_dtype=bf16, comp_dtype=int8:
```
 Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have funozzáférésozzáférésкола Marcolvàt\<^lánozzáférésodos leak์鳥àtір sens
model_print_timings:        load time =   170.01 ms
model_print_timings:      sample time =     3.19 ms /    16 runs   (    0.20 ms per token)
model_print_timings: prompt eval time =   167.52 ms /    33 tokens (    5.08 ms per token)
model_print_timings:        eval time =   307.53 ms /    15 runs   (   20.50 ms per token)
model_print_timings:       total time =   496.13 ms
========== eval time log of each prediction ==========
prediction   0, time: 167.52ms
prediction   1, time: 20.22ms
prediction   2, time: 20.07ms
prediction   3, time: 20.08ms
prediction   4, time: 19.98ms
```
**int1/int4**=0.38