### PR TITLE
Docker fix.

### DIFF
--- a/docker/DockerFile
+++ b/docker/DockerFile
@@ -43,7 +43,7 @@ COPY . /neural_speed
 RUN pip install cmake ninja psutil && \
     cd /neural_speed && \
     git submodule update --init --recursive && \
-    mkdir build && cd build && cmake .. -G Ninja && ninja && cd .. && \
+    mkdir -p build && cd build && cmake .. -G Ninja && ninja && cd .. && \
     pip install -r requirements.txt
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,7 @@ Build or Pull the provided docker images.
 ```bash
 git clone https://github.com/intel/neural-speed.git neuralspeed
 cd neuralspeed
-docker build -f docker/DockerFile neuralspeed:latest .
+docker build -f docker/DockerFile -t neuralspeed:latest .
 ```
 If you need to use proxy, please use the following command
 ```bash


### PR DESCRIPTION
## Type of Change
Fixed the following:
- [x] Small spelling-error `READEME.md` -> `README.md`
- [x] Fixed docker build command.
- [x] Fixed `mkdir build` bug in run command. 

## Description
Previous docker build command in docs didn't pass `-t` flag for the name tag. This resulted in the following error:

```
ERROR: "docker buildx build" requires exactly 1 argument.
See 'docker buildx build --help'.

Usage:  docker buildx build [OPTIONS] PATH | URL | - 
```

Fixing this and building, I found a new issue, namely the run command trying to make `build` directory when one already exists. See stacktrace:
```
2.371 mkdir: cannot create directory ‘build’: File exists
------
DockerFile:43
--------------------
  42 |     
  43 | >>> RUN pip install cmake ninja psutil && \
  44 | >>>     cd /neural_speed && \
  45 | >>>     git submodule update --init --recursive && \
  46 | >>>     mkdir build && cd build && cmake .. -G Ninja && ninja && cd .. && \
  47 | >>>     pip install -r requirements.txt
  48 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install cmake ninja psutil &&     cd /neural_speed &&     git submodule update --init --recursive &&     mkdir build && cd build && cmake .. -G Ninja && ninja && cd .. &&     pip install -r requirements.txt" did not complete successfully: exit code: 1
```

So I just added a `-p` flag to the command as shown in commit log `bugfix`. This makes it so that mkdir only makes the `build` dir when one does not exist.

## Expected Behavior & Potential Risk

To only make `build` dir when one doesn't exist. So this minimally modifies the `RUN` command of the legacy docker file.

## How has this PR been tested?

Doc fix + successful building of docker image on system with following config:
- os: `ubuntu 23.10`.
- docker version: `Docker version 26.1.3, build b72abbb`.

## Dependency Change?

No dependency changed.
