### PR TITLE
fix block1d max load/store/prefetch bytes

### DIFF
--- a/include/common/core/arch_config.hpp
+++ b/include/common/core/arch_config.hpp
@@ -93,16 +93,16 @@ inline constexpr bool arch_has_2d_load_store =
 
 template <gpu_arch arch_tag>
 struct load_store_attr_t<msg_type::block_1d, arch_tag> {
-  static constexpr uint32_t max_load_vec_len = 32;
-  static constexpr uint32_t max_store_vec_len = 32;
-  static constexpr uint32_t max_prefetch_vec_len = 32;
+  static constexpr uint32_t max_load_vec_in_bytes = 256;
+  static constexpr uint32_t max_store_vec_in_bytes = 256;
+  static constexpr uint32_t max_prefetch_vec_in_bytes = 256;
 };
 
 template <>
 struct load_store_attr_t<msg_type::block_1d, gpu_arch::XeHpc> {
-  static constexpr uint32_t max_load_vec_len = 64;
-  static constexpr uint32_t max_store_vec_len = 64;
-  static constexpr uint32_t max_prefetch_vec_len = 64;
+  static constexpr uint32_t max_load_vec_in_bytes = 512;
+  static constexpr uint32_t max_store_vec_in_bytes = 512;
+  static constexpr uint32_t max_prefetch_vec_in_bytes = 512;
 };
 
 struct dpas_attr_base_t {

--- a/include/subgroup/tile/impl/prefetch_xe.hpp
+++ b/include/subgroup/tile/impl/prefetch_xe.hpp
@@ -150,7 +150,9 @@ tile_prefetch(payload_t& payload) {
   using prefetch_dtype = typename payload_t::prefetch_dtype;
   constexpr uint32_t prefetch_len =
       tile_desc::tile_size_x / payload_t::scale_factor;
-  constexpr uint32_t max_prefetch_in_bytes = load_store_attr_t<msg_type::block_1d, payload_t::arch_tag>::max_prefetch_vec_len;
+  constexpr uint32_t max_prefetch_in_bytes =
+      load_store_attr_t<msg_type::block_1d, payload_t::arch_tag>::
+          max_prefetch_vec_in_bytes;
   if constexpr (prefetch_len >= max_prefetch_in_bytes) {
 #pragma unroll
     for (uint32_t j = 0; j < prefetch_len / max_prefetch_in_bytes; j++) {
@@ -165,10 +167,11 @@ tile_prefetch(payload_t& payload) {
     }
   }
   constexpr uint32_t tail_len = prefetch_len % max_prefetch_in_bytes;
-  uint32_t tail_offset =
-      prefetch_len / max_prefetch_in_bytes * max_prefetch_in_bytes * payload_t::scale_factor;
-  detail::process_1d_tail<tail_len, max_prefetch_in_bytes / 2, L1, L2, payload_t>(
-      payload, tail_offset);
+  uint32_t tail_offset = prefetch_len / max_prefetch_in_bytes *
+      max_prefetch_in_bytes * payload_t::scale_factor;
+  detail::
+      process_1d_tail<tail_len, max_prefetch_in_bytes / 2, L1, L2, payload_t>(
+          payload, tail_offset);
 }
 
 /// @brief Is prefetch data func.
@@ -183,8 +186,8 @@ template <
     cache_hint L1 = cache_hint::cached,
     cache_hint L2 = cache_hint::cached,
     typename payload_t>
-__XETLA_API typename std::enable_if_t<
-    detail::check_prefetch_type<payload_t>::is_local>
-tile_prefetch([[maybe_unused]] payload_t& payload) {}
+__XETLA_API
+    typename std::enable_if_t<detail::check_prefetch_type<payload_t>::is_local>
+    tile_prefetch([[maybe_unused]] payload_t& payload) {}
 
 } // namespace gpu::xetla::subgroup


### PR DESCRIPTION
## Type of Change

feature or bug fix or documentation or others
bugfix

API changed or not
not

## Description

https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd_functions.md#table1---valid-values-of-n-if-cache-hints-are-used-or-pred-parameter-is-passed
![image](https://github.com/intel/neural-speed/assets/16934286/0812638c-cee6-44c5-a099-93892b19bb53)

According to esimd spec, DG2 is up to 256 bytes and pvc is 512 bytes. The previous arch config description is wrong.


detail description 
Issues: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
