### PR TITLE
[BesTLA] Simplify the templates

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,6 +40,18 @@
       }
     },
     {
+      "name": "linux-release-ut-thread",
+      "displayName": "Linux Release Thread Pool for UTs",
+      "description": "Release",
+      "inherits": "linux-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "NS_USE_OMP": "OFF",
+        "BTLA_UT_ALL": "ON",
+        "BTLA_UT_BENCHMARK": "ON"
+      }
+    },
+    {
       "name": "windows-base",
       "description": "Target Windows with the Visual Studio development environment.",
       "hidden": true,

--- a/bestla/bestla/bestla_device.h
+++ b/bestla/bestla/bestla_device.h
@@ -233,9 +233,9 @@ class CpuDevice {
   inline bool AVX512_BF16() { return mHasAVX512_BF16; }
   inline bool AVX512_FP16() { return mHasAVX512_FP16; }
   inline float* const getPE() { return PE; }
-  inline size_t getPcoreNum() { return P_core.size(); }
-  inline size_t getEcoreNum() { return E_core.size(); }
-  inline size_t getSMTcoreNum() { return SMT_core.size(); }
+  inline int getPcoreNum() { return static_cast<int>(P_core.size()); }
+  inline int getEcoreNum() { return static_cast<int>(E_core.size()); }
+  inline int getSMTcoreNum() { return static_cast<int>(SMT_core.size()); }
   inline int* getPCores() { return P_core.data(); }
   inline int* getECores() { return E_core.data(); }
   inline int* getSMTCores() { return SMT_core.data(); }
@@ -467,15 +467,15 @@ class CpuDevice {
   bool isClient() { return mClient; }
 
  protected:
-  uint32_t L2Cache, L1Cache, L3Cache;
+  uint32_t L2Cache = 0, L1Cache = 0, L3Cache = 0;
   bool mHybrid = false, mClient = false;
-  bool mHasAVX2, mHasAVX_VNNI, mHasAVX, mHasAVX512_VNNI, mHasAMX_INT8, mHasAMX_BF16, mHasAVX512F, mHasAVX512BW,
-      mHasAVX512_BF16, mHasAVX512_FP16;
-  int numcores;
-  int numthreads;
+  bool mHasAVX2 = false, mHasAVX_VNNI = false, mHasAVX = false, mHasAVX512_VNNI = false, mHasAMX_INT8 = false,
+       mHasAMX_BF16 = false, mHasAVX512F = false, mHasAVX512BW, mHasAVX512_BF16 = false, mHasAVX512_FP16 = false;
+  int numcores = 0;
+  int numthreads = 0;
   std::vector<int> P_core, E_core, SMT_core;
-  uint32_t E_L2Cache, E_L1Cache;
-  float PE[int(BTLA_ISA::ISA_COUNT)];
+  uint32_t E_L2Cache = 0, E_L1Cache = 0;
+  float PE[int(BTLA_ISA::ISA_COUNT)] = {1.f};
 };
 
 #define GetCPUDevice() auto _cd = bestla::device::CpuDevice::getInstance();

--- a/bestla/bestla/bestla_gemm.h
+++ b/bestla/bestla/bestla_gemm.h
@@ -2510,7 +2510,7 @@ class Avx512vnniN16P4 : protected bestla::xbyak::JitAvx512vnni {
   static_assert(_NTILE % RegLen == 0);
   static int constexpr NRegs = _NTILE / RegLen;
   static int constexpr MRegs = _MTILE == 0 ? (RegCount - 1 - NRegs) / (NRegs * 2) : _MTILE;
-  static_assert(NRegs * MRegs <= RegCount - 1);
+  static_assert(NRegs * MRegs * 2 <= RegCount - 1);
   static int constexpr NTILE = RegLen * NRegs, MTILE = MRegs, KTILE = 4;
   static int constexpr KUNROLL = 2;
   static auto constexpr ISA = BTLA_ISA::AVX512_VNNI;
@@ -3397,7 +3397,7 @@ class AvxvnniN8P4 : protected bestla::xbyak::JitAvxvnni {
   static_assert(_NTILE % RegLen == 0);
   static int constexpr NRegs = _NTILE / RegLen;
   static int constexpr MRegs = _MTILE == 0 ? (RegCount - 3) / (NRegs * 2) : _MTILE;
-  static_assert(NRegs * MRegs <= RegCount - 3);
+  static_assert(NRegs * MRegs * 2 <= RegCount - 3);
   static int constexpr NTILE = RegLen * NRegs, MTILE = MRegs, KTILE = 4;
   static int constexpr KUNROLL = 2;
   static auto constexpr ISA = BTLA_ISA::AVX_VNNI;
@@ -4073,7 +4073,7 @@ class Avx2vnniN8P4 : protected bestla::xbyak::JitAvx2 {
   static int constexpr NRegs = _NTILE / RegLen;
   static int constexpr TmpReserve = std::is_same_v<AT, uint8_t> ? 2 : 4;
   static int constexpr MRegs = _MTILE == 0 ? (RegCount - (TmpReserve + 1)) / (NRegs * 2) : _MTILE;
-  static_assert(NRegs * MRegs <= RegCount - (TmpReserve + 1));
+  static_assert(NRegs * MRegs * 2 <= RegCount - (TmpReserve + 1));
   static int constexpr NTILE = RegLen * NRegs, MTILE = MRegs, KTILE = 4;
   static int constexpr KUNROLL = 2;
   static auto constexpr ISA = BTLA_ISA::AVX2;

--- a/bestla/bestla/bestla_gemm.h
+++ b/bestla/bestla/bestla_gemm.h
@@ -4935,7 +4935,7 @@ class HCoreRowNAvx512bf16 : public CoreCodeBase<code::Avx512bf16N16P2, _NTILE, _
 template <int _NTILE, int _MTILE = 0>
 class HCoreRowNAmxbf16 : public CoreCodeBaseAMX<code::Amxbf16N16P2, _NTILE, _MTILE> {
  public:
-  using Base = CoreCodeBase<code::Amxbf16N16P2, _NTILE, _MTILE>;
+  using Base = CoreCodeBaseAMX<code::Amxbf16N16P2, _NTILE, _MTILE>;
   using Code = typename Base::Code;
   using AType = typename Code::AType;
   using BType = typename Code::BType;
@@ -5178,7 +5178,7 @@ class ICoreRowNAvx2vnniKBlockSS : public CoreCodeBase<code::kblock::Avx2vnniN8P4
 template <int _NTILE, int _MTILE = 0>
 class ICoreRowNAmxint8 : public CoreCodeBaseAMX<code::Amxint8N16P4US, _NTILE, _MTILE> {
  public:
-  using Base = CoreCodeBase<code::Amxint8N16P4US, _NTILE, _MTILE>;
+  using Base = CoreCodeBaseAMX<code::Amxint8N16P4US, _NTILE, _MTILE>;
   using Code = typename CoreCodeBaseAMX<code::Amxint8N16P4US, _NTILE, _MTILE>::Code;
   using AType = typename Code::AType;
   using BType = typename Code::BType;
@@ -5205,7 +5205,7 @@ class ICoreRowNAmxint8 : public CoreCodeBaseAMX<code::Amxint8N16P4US, _NTILE, _M
 template <int _NTILE, int _MTILE = 0>
 class ICoreRowNAmxint8SS : public CoreCodeBaseAMX<code::Amxint8N16P4SS, _NTILE, _MTILE> {
  public:
-  using Base = CoreCodeBase<code::Amxint8N16P4SS, _NTILE, _MTILE>;
+  using Base = CoreCodeBaseAMX<code::Amxint8N16P4SS, _NTILE, _MTILE>;
   using Code = typename CoreCodeBaseAMX<code::Amxint8N16P4SS, _NTILE, _MTILE>::Code;
   using AType = typename Code::AType;
   using BType = typename Code::BType;
@@ -5232,7 +5232,7 @@ class ICoreRowNAmxint8SS : public CoreCodeBaseAMX<code::Amxint8N16P4SS, _NTILE, 
 template <int _NTILE, int _MTILE = 0>
 class ICoreRowNAmxint8KBlock : public CoreCodeBaseAMX<code::kblock::Amxint8N16P4US, _NTILE, _MTILE> {
  public:
-  using Base = CoreCodeBase<code::kblock::Amxint8N16P4US, _NTILE, _MTILE>;
+  using Base = CoreCodeBaseAMX<code::kblock::Amxint8N16P4US, _NTILE, _MTILE>;
   using Code = typename CoreCodeBaseAMX<code::kblock::Amxint8N16P4US, _NTILE, _MTILE>::Code;
   using AType = typename Code::AType;
   using BType = typename Code::BType;
@@ -5261,7 +5261,7 @@ class ICoreRowNAmxint8KBlock : public CoreCodeBaseAMX<code::kblock::Amxint8N16P4
 template <int _NTILE, int _MTILE = 0>
 class ICoreRowNAmxint8SSKBlock : public CoreCodeBaseAMX<code::kblock::Amxint8N16P4SS, _NTILE, _MTILE> {
  public:
-  using Base = CoreCodeBase<code::kblock::Amxint8N16P4SS, _NTILE, _MTILE>;
+  using Base = CoreCodeBaseAMX<code::kblock::Amxint8N16P4SS, _NTILE, _MTILE>;
   using Code = typename CoreCodeBaseAMX<code::kblock::Amxint8N16P4SS, _NTILE, _MTILE>::Code;
   using AType = typename Code::AType;
   using BType = typename Code::BType;

--- a/bestla/bestla/bestla_parallel.h
+++ b/bestla/bestla/bestla_parallel.h
@@ -831,7 +831,7 @@ template <class Parallel_T, class Launch_T>
 void GemmRunWithA(Launch_T& launcher, const typename Launch_T::Param& args, parallel::IThreading* th) {
   gemm::SchedulerDispatcher<Parallel_T> para(th, args.problem);
   using AParall = typename Launch_T::PrologueA::Parallel;
-  AParall apara = launcher.mProA.createParallel(th->num_threads(), args.problem);
+  AParall apara = Launch_T::PrologueA::createParallel(th->num_threads(), args.problem);
   static bool flag = false;
   if (flag) {
     printf("%s\n", __FUNCTION__);
@@ -842,7 +842,7 @@ void GemmRunWithA(Launch_T& launcher, const typename Launch_T::Param& args, para
     typename AParall::ThreadProblem thdpA{tidx};
     apara.getIndex(thdpA);
     if (thdpA.valid) {
-      launcher.mProA.run(args.paramA, thdpA);
+      Launch_T::PrologueA::run<Launch_T::ISA>(args.paramA, thdpA);
     }
     th->sync(tidx);
     typename Parallel_T::ThreadProblem thdp{tidx};

--- a/bestla/bestla/bestla_parallel.h
+++ b/bestla/bestla/bestla_parallel.h
@@ -817,7 +817,7 @@ class SchedulerDispatcher<Scheduler2D> {
 }  // namespace gemm
 
 template <class Parallel_T, class Launch_T>
-void GemmRun(Launch_T& launcher, const typename Launch_T::Param& args, parallel::IThreading* th) {
+void GemmRun(const typename Launch_T::Param& args, parallel::IThreading* th) {
   gemm::SchedulerDispatcher<Parallel_T> para(th, args.problem);
   static bool flag = false;
   if (flag) {
@@ -829,13 +829,13 @@ void GemmRun(Launch_T& launcher, const typename Launch_T::Param& args, parallel:
     typename Parallel_T::ThreadProblem thdp{tidx};
     para.getIndex(thdp);
     if (thdp.valid) {
-      launcher.run(args, thdp);
+      Launch_T::run(args, thdp);
     }
   });
 }
 
 template <class Parallel_T, class Launch_T>
-void GemmRunWithA(Launch_T& launcher, const typename Launch_T::Param& args, parallel::IThreading* th) {
+void GemmRunWithA(const typename Launch_T::Param& args, parallel::IThreading* th) {
   gemm::SchedulerDispatcher<Parallel_T> para(th, args.problem);
   using AParall = typename Launch_T::PrologueA::Parallel;
   AParall apara = Launch_T::PrologueA::createParallel(th->num_threads(), args.problem);
@@ -855,7 +855,7 @@ void GemmRunWithA(Launch_T& launcher, const typename Launch_T::Param& args, para
     typename Parallel_T::ThreadProblem thdp{tidx};
     para.getIndex(thdp);
     if (thdp.valid) {
-      launcher.run(args, thdp);
+      Launch_T::run(args, thdp);
     }
   });
 }

--- a/bestla/bestla/bestla_parallel.h
+++ b/bestla/bestla/bestla_parallel.h
@@ -842,7 +842,7 @@ void GemmRunWithA(Launch_T& launcher, const typename Launch_T::Param& args, para
     typename AParall::ThreadProblem thdpA{tidx};
     apara.getIndex(thdpA);
     if (thdpA.valid) {
-      Launch_T::PrologueA::run<Launch_T::ISA>(args.paramA, thdpA);
+      Launch_T::PrologueA::run(args.paramA, thdpA);
     }
     th->sync(tidx);
     typename Parallel_T::ThreadProblem thdp{tidx};

--- a/bestla/bestla/bestla_parallel.h
+++ b/bestla/bestla/bestla_parallel.h
@@ -68,8 +68,8 @@ class IThreading {
   virtual std::pair<float, float> get_PEtime() const { return {0.0f, 0.0f}; };
 
  protected:
-  int mThreadNum;
-  const bool isSupportPE;
+  int mThreadNum = 0;
+  const bool isSupportPE = false;
 };
 
 #if BTLA_OPENMP
@@ -107,7 +107,14 @@ class OMPThreading : public IThreading {
 class StdThreading : public IThreading {
  public:
   using Timer_T = utils::timer<utils::microseconds>;
-  explicit StdThreading() : IThreading(true) { cr = nullptr; }
+  explicit StdThreading() : IThreading(true) {
+    cr = nullptr;
+    memset(func_, 0, sizeof(func_));
+    memset(flag, 0, sizeof(flag));
+    stop = true;
+    time_per_p = -1.f;
+    time_per_e = -1.f;
+  }
 
   void parallel_for(const thread_func& func) override {
     time_per_p = 0;
@@ -117,7 +124,7 @@ class StdThreading : public IThreading {
       running.store(mThreadNum - 1);
       for (int i = 0; i < 10; i++) flag[i].store(mThreadNum);
       if (cr->mHybrid) {
-        int time_p = 0, time_e = 0;
+        int64_t time_p = 0, time_e = 0;
 
         for (size_t i = 0; i < mThreadNum - 1; i++) func_[i] = &func;
         thread_time[0] = 0;
@@ -135,8 +142,8 @@ class StdThreading : public IThreading {
             time_e += thread_time[i];
           else
             time_p += thread_time[i];
-        time_per_p = (time_p) / (1.0 * (mThreadNum - cr->E_core_num));
-        time_per_e = (time_e) / (1.0 * cr->E_core_num);
+        time_per_p = (time_p) / (1.0f * (mThreadNum - cr->E_core_num));
+        time_per_e = (time_e) / (1.0f * cr->E_core_num);
         // printf("%d %d %f %f\n", time_p, time_e, time_per_p, time_per_e);
       } else {
         for (size_t i = 0; i < mThreadNum - 1; i++) {

--- a/bestla/bestla/bestla_prologue_a.h
+++ b/bestla/bestla/bestla_prologue_a.h
@@ -34,14 +34,14 @@ struct ParamActivationBase {
   const AType* A;
   int lda;
 };
-template <class _GemmCore_T, BTLA_ISA ISA_T>
+template <class _GemmCore_T>
 class ActivationBase {
  public:
   using AType = typename _GemmCore_T::AType;
   using SRCType = AType;
   using Param = ParamActivationBase<AType>;
-  BTLA_CODE getActivation(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
-                          int k_offset, void* tmpcache, size_t cachesize) {
+  TLACALL BTLA_CODE getActivation(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size,
+                                  int m_offset, int k_offset, void* tmpcache, size_t cachesize) {
     auto aptr = const_cast<AType*>(_param.A) + m_offset * _param.lda + k_offset;
     auto alignedptr = utils::cpu_pointer_align(aptr);
     bool use_rawptr = k_size % _GemmCore_T::KTILE == 0 && m_size >= _GemmCore_T::MTILE;
@@ -59,14 +59,14 @@ class ActivationBase {
   }
 };
 
-template <class _GemmCore_T, BTLA_ISA ISA_T, typename SRC_T>
-class ActivationConverter : public ActivationBase<_GemmCore_T, ISA_T> {
+template <class _GemmCore_T, typename SRC_T>
+class ActivationConverter : public ActivationBase<_GemmCore_T> {
  public:
   using AType = typename _GemmCore_T::AType;
   using SRCType = SRC_T;
   using Param = ParamActivationBase<SRC_T>;
-  BTLA_CODE getActivation(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
-                          int k_offset, void* tmpcache, size_t cachesize) {
+  TLACALL BTLA_CODE getActivation(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size,
+                                  int m_offset, int k_offset, void* tmpcache, size_t cachesize) {
     auto aptr = const_cast<SRC_T*>(_param.A);
     auto k_pad = utils::padto(k_size, _GemmCore_T::KTILE);
     *dststep = k_pad;
@@ -83,8 +83,8 @@ class ActivationConverter : public ActivationBase<_GemmCore_T, ISA_T> {
                                                                   m_size, k_size, _param.lda * sizeof(SRC_T),
                                                                   k_pad * sizeof(AType), true);
     } else if constexpr (std::is_same_v<AType, SRC_T>) {
-      return ActivationBase<_GemmCore_T, ISA_T>::getActivation(dstptr, dststep, {_param.A, _param.lda}, m_size, k_size,
-                                                               m_offset, k_offset, tmpcache, cachesize);
+      return ActivationBase<_GemmCore_T>::template getActivation<ISA_T>(
+          dstptr, dststep, {_param.A, _param.lda}, m_size, k_size, m_offset, k_offset, tmpcache, cachesize);
     } else {
       assert(0);
     }
@@ -92,16 +92,16 @@ class ActivationConverter : public ActivationBase<_GemmCore_T, ISA_T> {
   }
 };
 
-template <class _GemmCore_T, BTLA_ISA ISA_T>
-using ActivationConverterFp32 = ActivationConverter<_GemmCore_T, ISA_T, float>;
-template <class _GemmCore_T, BTLA_ISA ISA_T>
-using ActivationConverterBf16 = ActivationConverter<_GemmCore_T, ISA_T, utils::bf16>;
+template <class _GemmCore_T>
+using ActivationConverterFp32 = ActivationConverter<_GemmCore_T, float>;
+template <class _GemmCore_T>
+using ActivationConverterBf16 = ActivationConverter<_GemmCore_T, utils::bf16>;
 
 template <typename AType>
 struct ParamActivationKBlockQuantize : ParamActivationBase<AType> {
   storage::gemm::StorageQuantActivation* quan;
 };
-template <class _GemmCore_T, BTLA_ISA ISA_T, typename SRC_T>
+template <class _GemmCore_T, typename SRC_T>
 class ActivationKBlockQuantize {
  public:
   using AType = typename _GemmCore_T::AType;
@@ -112,7 +112,7 @@ class ActivationKBlockQuantize {
   using Parallel = parallel::Scheduler2D;
   using ThreadProblem = parallel::ThreadProblem2D;
 
-  inline Parallel createParallel(int nthreads, const utils::GemmProblem& prbm) {
+  static Parallel createParallel(int nthreads, const utils::GemmProblem& prbm) {
     return Parallel({
         nthreads, prbm.dims[1],  // m
         prbm.dims[3],            // k
@@ -121,7 +121,7 @@ class ActivationKBlockQuantize {
     });
   }
 
-  inline QParam createStorage(int m, int k, int kblock, bool hasreduce) {
+  static QParam createStorage(int m, int k, int kblock, bool hasreduce) {
     QParam tmp;
     int kpad = utils::padto(k, _GemmCore_T::KTILE);
     int mpad = utils::padto(m, _GemmCore_T::MTILE);
@@ -130,7 +130,7 @@ class ActivationKBlockQuantize {
     return tmp;
   }
 
-  void run(const Param& _param, ThreadProblem& thdp) {
+  ISACALL void run(const Param& _param, ThreadProblem& thdp) {
     auto quan = _param.quan;
     if (thdp.valid) {
       // min max
@@ -153,19 +153,19 @@ class ActivationKBlockQuantize {
     }
   }
 
-  BTLA_CODE quantize(const Param& _param, int m, int k, parallel::IThreading* threading) {
+  ISACALL BTLA_CODE quantize(const Param& _param, int m, int k, parallel::IThreading* threading) {
     auto paral = Parallel({threading->num_threads(), m, k, 1, _param.quan->mBlockSize});
     threading->parallel_for([&](int tidx) {
       parallel::ThreadProblem2D thdp{tidx};
       paral.getIndex(thdp);
-      if (thdp.valid) run(_param, thdp);
+      if (thdp.valid) run<ISA_T>(_param, thdp);
     });
     return BTLA_CODE::Success;
   }
 
  public:  // Runtime get by launcher
-  BTLA_CODE getActivation(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
-                          int k_offset, void* tmpcache, size_t cachesize) {
+  TLACALL BTLA_CODE getActivation(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size,
+                                  int m_offset, int k_offset, void* tmpcache, size_t cachesize) {
     (void)m_size;
     (void)k_size;
     auto quan = _param.quan;
@@ -175,8 +175,8 @@ class ActivationKBlockQuantize {
     return BTLA_CODE::Success;
   }
 
-  BTLA_CODE getZp(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset, int k_offset,
-                  void* tmpcache, size_t cachesize) {
+  TLACALL BTLA_CODE getZp(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
+                          int k_offset, void* tmpcache, size_t cachesize) {
     auto quan = _param.quan;
     auto aptr = quan->template ZPtr<AType>();
     if (aptr == nullptr) {  // optional
@@ -190,8 +190,8 @@ class ActivationKBlockQuantize {
     return BTLA_CODE::Success;
   }
 
-  BTLA_CODE getScale(float** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
-                     int k_offset, void* tmpcache, size_t cachesize) {
+  TLACALL BTLA_CODE getScale(float** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
+                             int k_offset, void* tmpcache, size_t cachesize) {
     auto quan = _param.quan;
     auto aptr = quan->template SPtr<float>();
     int kele = utils::updiv(k_size, quan->mBlockSize);
@@ -201,8 +201,8 @@ class ActivationKBlockQuantize {
     return BTLA_CODE::Success;
   }
 
-  BTLA_CODE getReduce(float** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
-                      int k_offset, void* tmpcache, size_t cachesize) {
+  TLACALL BTLA_CODE getReduce(float** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
+                              int k_offset, void* tmpcache, size_t cachesize) {
     auto quan = _param.quan;
     auto aptr = quan->template RPtr<float>();
     int kele = utils::updiv(k_size, quan->mBlockSize);
@@ -213,17 +213,17 @@ class ActivationKBlockQuantize {
   }
 };
 
-template <class _GemmCore_T, BTLA_ISA ISA_T>
-using ActivationF32KBlockQuantize = ActivationKBlockQuantize<_GemmCore_T, ISA_T, float>;
-template <class _GemmCore_T, BTLA_ISA ISA_T>
-using ActivationBf16KBlockQuantize = ActivationKBlockQuantize<_GemmCore_T, ISA_T, utils::bf16>;
+template <class _GemmCore_T>
+using ActivationF32KBlockQuantize = ActivationKBlockQuantize<_GemmCore_T, float>;
+template <class _GemmCore_T>
+using ActivationBf16KBlockQuantize = ActivationKBlockQuantize<_GemmCore_T, utils::bf16>;
 
 template <typename AType>
 struct ParamActivationKBlockBase : ParamActivationBase<AType> {
   storage::gemm::StorageReduce* reduce;
 };
-template <class _GemmCore_T, BTLA_ISA ISA_T, typename SRC_T>
-class ActivationKBlockBase : public ActivationConverter<_GemmCore_T, ISA_T, SRC_T> {
+template <class _GemmCore_T, typename SRC_T>
+class ActivationKBlockBase : public ActivationConverter<_GemmCore_T, SRC_T> {
  public:
   using AType = typename _GemmCore_T::AType;
   using SType = storage::gemm::StorageReduce;
@@ -232,7 +232,7 @@ class ActivationKBlockBase : public ActivationConverter<_GemmCore_T, ISA_T, SRC_
   using Parallel = parallel::Scheduler2D;
   using ThreadProblem = parallel::ThreadProblem2D;
 
-  inline Parallel createParallel(int nthreads, const utils::GemmProblem& prbm) {
+  static Parallel createParallel(int nthreads, const utils::GemmProblem& prbm) {
     return Parallel({
         nthreads, prbm.dims[1],  // m
         prbm.dims[3],            // k
@@ -240,13 +240,13 @@ class ActivationKBlockBase : public ActivationConverter<_GemmCore_T, ISA_T, SRC_
         prbm.dims[4]  // kblock
     });
   }
-  inline SType createStorage(int m, int k, int kblock) {
+  static SType createStorage(int m, int k, int kblock) {
     SType tmp;
     tmp.resize(m, k, kblock == -1 ? k : kblock, BTLA_DTYPE::F32);
     return tmp;
   }
 
-  void run(const Param& _param, ThreadProblem& thdp) {
+  ISACALL void run(const Param& _param, ThreadProblem& thdp) {
     auto stor = _param.reduce;
     if (thdp.valid) {
       // min max
@@ -259,24 +259,24 @@ class ActivationKBlockBase : public ActivationConverter<_GemmCore_T, ISA_T, SRC_
     }
   }
 
-  BTLA_CODE reduce(const Param& _param, int m, int k, int kblock, parallel::IThreading* threading) {
+  ISACALL BTLA_CODE reduce(const Param& _param, int m, int k, int kblock, parallel::IThreading* threading) {
     auto paral = Parallel({threading->num_threads(), m, k, 1, kblock});
     threading->parallel_for([&](int tidx) {
       parallel::ThreadProblem2D thdp{tidx};
       paral.getIndex(thdp);
-      if (thdp.valid) run(_param, thdp);
+      if (thdp.valid) run<ISA_T>(_param, thdp);
     });
     return BTLA_CODE::Success;
   }
 
-  BTLA_CODE getActivation(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
-                          int k_offset, void* tmpcache, size_t cachesize) {
-    return ActivationConverter<_GemmCore_T, ISA_T, SRC_T>::getActivation(
+  TLACALL BTLA_CODE getActivation(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size,
+                                  int m_offset, int k_offset, void* tmpcache, size_t cachesize) {
+    return ActivationConverter<_GemmCore_T, SRC_T>::template getActivation<ISA_T>(
         dstptr, dststep, {_param.A, _param.lda}, m_size, k_size, m_offset, k_offset, tmpcache, cachesize);
   }
 
-  BTLA_CODE getReduce(float** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
-                      int k_offset, void* tmpcache, size_t cachesize) {
+  TLACALL BTLA_CODE getReduce(float** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
+                              int k_offset, void* tmpcache, size_t cachesize) {
     auto reduce = _param.reduce;
     auto aptr = reduce->template RPtr<float>();
     int kele = utils::updiv(k_size, reduce->kblock);
@@ -287,16 +287,16 @@ class ActivationKBlockBase : public ActivationConverter<_GemmCore_T, ISA_T, SRC_
   }
 };
 
-template <class _GemmCore_T, BTLA_ISA ISA_T>
-using ActivationKBlockBaseF32 = ActivationKBlockBase<_GemmCore_T, ISA_T, float>;
+template <class _GemmCore_T>
+using ActivationKBlockBaseF32 = ActivationKBlockBase<_GemmCore_T, float>;
 
 template <typename AType>
 struct ParamShuffleActivationKBlockBase : ParamActivationKBlockBase<AType> {
   int* indices = nullptr;
   storage::gemm::StorageReorderActivation* reordered = nullptr;
 };
-template <class _GemmCore_T, BTLA_ISA ISA_T, typename SRC_T>
-class ShuffleActivationKBlockBase : public ActivationKBlockBase<_GemmCore_T, ISA_T, SRC_T> {
+template <class _GemmCore_T, typename SRC_T>
+class ShuffleActivationKBlockBase : public ActivationKBlockBase<_GemmCore_T, SRC_T> {
  public:
   using AType = typename _GemmCore_T::AType;
   using RedType = storage::gemm::StorageReduce;
@@ -305,7 +305,7 @@ class ShuffleActivationKBlockBase : public ActivationKBlockBase<_GemmCore_T, ISA
   using Param = ParamShuffleActivationKBlockBase<SRC_T>;
   using Parallel = parallel::Scheduler2D;
   using ThreadProblem = parallel::ThreadProblem2D;
-  inline RAType createReorderStorage(int m, int k, int kblock) {
+  static RAType createReorderStorage(int m, int k, int kblock) {
     RAType tmp(_GemmCore_T::ID);
     int kpad = utils::padto(k, _GemmCore_T::KTILE);
     int mpad = utils::padto(m, _GemmCore_T::MTILE);
@@ -313,13 +313,13 @@ class ShuffleActivationKBlockBase : public ActivationKBlockBase<_GemmCore_T, ISA
     return tmp;
   }
 
-  inline RedType createReduceStorage(int m, int k, int kblock) {
+  static RedType createReduceStorage(int m, int k, int kblock) {
     RedType tmp;
     tmp.resize(m, k, kblock == -1 ? k : kblock, BTLA_DTYPE::F32);
     return tmp;
   }
 
-  void run(const Param& _param, ThreadProblem& thdp) {
+  ISACALL void run(const Param& _param, ThreadProblem& thdp) {
     auto stor = _param.reduce;
     auto reordered = _param.reordered;
     if (thdp.valid) {
@@ -342,41 +342,41 @@ class ShuffleActivationKBlockBase : public ActivationKBlockBase<_GemmCore_T, ISA
     }
   }
 
-  BTLA_CODE preprocess(const Param& _param, int m, int k, int kblock, parallel::IThreading* threading) {
+  ISACALL BTLA_CODE preprocess(const Param& _param, int m, int k, int kblock, parallel::IThreading* threading) {
     auto paral = Parallel({threading->num_threads(), m, k, 1, kblock});
     threading->parallel_for([&](int tidx) {
       parallel::ThreadProblem2D thdp{tidx};
       paral.getIndex(thdp);
-      run(_param, thdp);
+      run<ISA_T>(_param, thdp);
     });
     return BTLA_CODE::Success;
   }
 
-  BTLA_CODE getActivation(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
-                          int k_offset, void* tmpcache, size_t cachesize) {
+  TLACALL BTLA_CODE getActivation(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size,
+                                  int m_offset, int k_offset, void* tmpcache, size_t cachesize) {
     if (_param.indices == nullptr) {
-      return ActivationConverter<_GemmCore_T, ISA_T, SRC_T>::getActivation(
+      return ActivationConverter<_GemmCore_T, SRC_T>::template getActivation<ISA_T>(
           dstptr, dststep, {_param.A, _param.lda}, m_size, k_size, m_offset, k_offset, tmpcache, cachesize);
     } else {
-      return ActivationConverter<_GemmCore_T, ISA_T, SRC_T>::getActivation(
+      return ActivationConverter<_GemmCore_T, SRC_T>::template getActivation<ISA_T>(
           dstptr, dststep, {_param.reordered->template APtr<SRC_T>(), _param.reordered->mKPad}, m_size, k_size,
           m_offset, k_offset, tmpcache, cachesize);
     }
   }
 };
 
-template <class _GemmCore_T, BTLA_ISA ISA_T>
-using ShuffleActivationKBlockBaseF32 = ShuffleActivationKBlockBase<_GemmCore_T, ISA_T, float>;
-template <class _GemmCore_T, BTLA_ISA ISA_T>
-using ShuffleActivationKBlockBaseBf16 = ShuffleActivationKBlockBase<_GemmCore_T, ISA_T, utils::bf16>;
+template <class _GemmCore_T>
+using ShuffleActivationKBlockBaseF32 = ShuffleActivationKBlockBase<_GemmCore_T, float>;
+template <class _GemmCore_T>
+using ShuffleActivationKBlockBaseBf16 = ShuffleActivationKBlockBase<_GemmCore_T, utils::bf16>;
 
 template <typename AType>
 struct ParamShuffleActivationKBlockQuantize : ParamActivationKBlockQuantize<AType> {
   int* indices = nullptr;
   storage::gemm::StorageReorderActivation* reordered = nullptr;
 };
-template <class _GemmCore_T, BTLA_ISA ISA_T, typename SRC_T>
-class ShuffleActivationKBlockQuantize : public ActivationKBlockQuantize<_GemmCore_T, ISA_T, SRC_T> {
+template <class _GemmCore_T, typename SRC_T>
+class ShuffleActivationKBlockQuantize : public ActivationKBlockQuantize<_GemmCore_T, SRC_T> {
  public:
   using AType = typename _GemmCore_T::AType;
   using SType = float;
@@ -387,7 +387,7 @@ class ShuffleActivationKBlockQuantize : public ActivationKBlockQuantize<_GemmCor
   using Parallel = parallel::Scheduler2D;
   using ThreadProblem = parallel::ThreadProblem2D;
 
-  inline QParam createQuantStorage(int m, int k, int kblock, bool hasreduce) {
+  static QParam createQuantStorage(int m, int k, int kblock, bool hasreduce) {
     QParam tmp;
     int kpad = utils::padto(k, _GemmCore_T::KTILE);
     int mpad = utils::padto(m, _GemmCore_T::MTILE);
@@ -396,7 +396,7 @@ class ShuffleActivationKBlockQuantize : public ActivationKBlockQuantize<_GemmCor
     return tmp;
   }
 
-  inline RAType createReorderStorage(int m, int k, int kblock) {
+  static RAType createReorderStorage(int m, int k, int kblock) {
     RAType tmp(_GemmCore_T::ID);
     int kpad = utils::padto(k, _GemmCore_T::KTILE);
     int mpad = utils::padto(m, _GemmCore_T::MTILE);
@@ -404,7 +404,7 @@ class ShuffleActivationKBlockQuantize : public ActivationKBlockQuantize<_GemmCor
     return tmp;
   }
 
-  BTLA_CODE quantize(const Param& _param, int m, int k, parallel::IThreading* threading) {
+  ISACALL BTLA_CODE quantize(const Param& _param, int m, int k, parallel::IThreading* threading) {
     auto srcptr = const_cast<SRC_T*>(_param.A);
     if (_param.indices) {
       auto shuffle_src = _param.reordered->template APtr<SRC_T>();
@@ -417,15 +417,15 @@ class ShuffleActivationKBlockQuantize : public ActivationKBlockQuantize<_GemmCor
       });
       srcptr = shuffle_src;
     }
-    ActivationKBlockQuantize<_GemmCore_T, ISA_T, SRC_T>::quantize({srcptr, k, _param.quan}, m, k, threading);
+    ActivationKBlockQuantize<_GemmCore_T, SRC_T>::template quantize<ISA_T>({srcptr, k, _param.quan}, m, k, threading);
     return BTLA_CODE::Success;
   }
 };
 
-template <class _GemmCore_T, BTLA_ISA ISA_T>
-using ShuffleActivationKBlockQuantizeF32 = ShuffleActivationKBlockQuantize<_GemmCore_T, ISA_T, float>;
-template <class _GemmCore_T, BTLA_ISA ISA_T>
-using ShuffleActivationKBlockQuantizeBf16 = ShuffleActivationKBlockQuantize<_GemmCore_T, ISA_T, utils::bf16>;
+template <class _GemmCore_T>
+using ShuffleActivationKBlockQuantizeF32 = ShuffleActivationKBlockQuantize<_GemmCore_T, float>;
+template <class _GemmCore_T>
+using ShuffleActivationKBlockQuantizeBf16 = ShuffleActivationKBlockQuantize<_GemmCore_T, utils::bf16>;
 }  // namespace gemm
 }  // namespace prologue_a
 }  // namespace bestla

--- a/bestla/bestla/bestla_prologue_b.h
+++ b/bestla/bestla/bestla_prologue_b.h
@@ -347,7 +347,7 @@ class WeightKBlockNInteger {
           if (scales) {
             for (int i = thdp.loc[1]; i < thdp.loc[1] + thdp.size[1]; i++) {
               if (i < rawnk_scale) {
-                for (size_t j = 0; j < N; j++) {
+                for (int j = 0; j < N; j++) {
                   stor->template SPtr<float>()[i * stor->mNPad + j] = scales[j * rawnk_scale + i];
                 }
               } else {
@@ -365,7 +365,7 @@ class WeightKBlockNInteger {
           if (scales) {
             for (int i = thdp.loc[1]; i < thdp.loc[1] + thdp.size[1]; i++) {
               if (i < rawnk_scale) {
-                for (size_t j = 0; j < N; j++) {
+                for (int j = 0; j < N; j++) {
                   stor->template SPtr<utils::bf16>()[i * stor->mNPad + j] = utils::bf16(scales[j * rawnk_scale + i]);
                 }
               } else {
@@ -383,7 +383,7 @@ class WeightKBlockNInteger {
           if (scales) {
             for (int i = thdp.loc[1]; i < thdp.loc[1] + thdp.size[1]; i++) {
               if (i < rawnk_scale) {
-                for (size_t j = 0; j < N; j++) {
+                for (int j = 0; j < N; j++) {
                   stor->template SPtr<utils::f8>()[i * stor->mNPad + j] = scales[j * rawnk_scale + i];
                 }
               } else {
@@ -403,7 +403,7 @@ class WeightKBlockNInteger {
         if (thdp.valid) {
           for (int i = thdp.loc[1]; i < thdp.loc[1] + thdp.size[1]; i++) {
             if (i < rawnk_scale) {
-              for (size_t j = 0; j < N; j++) {
+              for (int j = 0; j < N; j++) {
                 stor->template ZPtr<int8_t>()[i * stor->mNPad + j] = zero_points[j * rawnk_scale + i];
               }
             } else {
@@ -1189,7 +1189,7 @@ class WeightKBlockNFloat {
           for (int i = thdp.loc[1]; i < thdp.loc[1] + thdp.size[1]; i++) {
             if (i < rawnk_scale) {
               if (scales != nullptr) {
-                for (size_t j = 0; j < N; j++) {
+                for (int j = 0; j < N; j++) {
                   stor->template SPtr<utils::bf16>()[j + i * stor->mNPad] = static_cast<utils::bf16>(scales[i * N + j]);
                 }
               }
@@ -1214,7 +1214,7 @@ class WeightKBlockNFloat {
           for (int i = thdp.loc[1]; i < thdp.loc[1] + thdp.size[1]; i++) {
             if (i < rawnk_scale) {
               if (scales != nullptr) {
-                for (size_t j = 0; j < N; j++) {
+                for (int j = 0; j < N; j++) {
                   stor->template SPtr<utils::f8>()[j + i * stor->mNPad] = static_cast<int8_t>(scales[i * N + j]);
                 }
               }
@@ -1233,7 +1233,7 @@ class WeightKBlockNFloat {
           for (int i = thdp.loc[1]; i < thdp.loc[1] + thdp.size[1]; i++) {
             if (i < rawnk_scale) {
               if (scales != nullptr) {
-                for (size_t j = 0; j < N; j++) {
+                for (int j = 0; j < N; j++) {
                   stor->template SPtr<uint8_t>()[j + i * stor->mNPad] = static_cast<uint8_t>(scales[i * N + j]);
                 }
               }

--- a/bestla/bestla/bestla_prologue_b.h
+++ b/bestla/bestla/bestla_prologue_b.h
@@ -1124,7 +1124,6 @@ class WeightKBlockNFloat {
     });
   }
 
-  
   AUTOCALL void setDoubleQuantCorrection(utils::avector<float>* dq_buf, StorageWeight* ptr) {
     if (ptr->SDtype() == BTLA_DTYPE::DQ8_BNB) {
       auto packw_dqbuf_ptr = ptr->DQPtr<float>();

--- a/bestla/bestla/bestla_prologue_b.h
+++ b/bestla/bestla/bestla_prologue_b.h
@@ -355,7 +355,7 @@ class WeightKBlockNInteger {
       _para.getIndex(thdp);
       if (thdp.valid) {
         auto siptr = stor->ShfIndice();
-        for (size_t i = 0; i < stor->mK; i++) {
+        for (int i = 0; i < stor->mK; i++) {
           if (groupindices[i] >= thdp.loc[1] && groupindices[i] < thdp.loc[1] + thdp.size[1]) {
             siptr[groupindices[i] * stor->mBlockSize + countptr[groupindices[i]]] = i;
             countptr[groupindices[i]]++;
@@ -761,7 +761,7 @@ class WeightKBlockNInteger {
     if (wptr->SDtype() == BTLA_DTYPE::DQ8_BNB) {
       auto aptr = wptr->template SPtr<uint8_t>();
       auto internal_k_offset = k_offset / wptr->mBlockSize;
-      auto dq_offset_idx = wptr->mCorrection.mDQCorrectionBuf.mBufSize / sizeof(float) - 1;
+      auto dq_offset_idx = static_cast<int>(wptr->mCorrection.mDQCorrectionBuf.mBufSize / sizeof(float) - 1);
       kernel::wrapper::Dq8GetScale::template forward<ISA_T>(
           aptr + internal_k_offset * wptr->CStep() + n_offset, *dstptr, utils::updiv(k_size, wptr->mBlockSize), n_size,
           internal_k_offset * wptr->mN + n_offset, wptr->mDqBlockSize, dq_offset_idx, wptr->DQPtr<float>(),
@@ -1066,7 +1066,7 @@ struct ParamWeightKBlockNFloat {
 template <class _GemmCore_T>
 class WeightKBlockNFloat {
  public:
-  using Param = ParamWeightKBlockNInteger;  // NFloat storage Param same with NInteger storage.
+  using Param = ParamWeightKBlockNFloat;  // NFloat storage Param same with NInteger storage.
   using StorageWeight = storage::gemm::StorageWeightKBlockNFloat;
   using QuantBaseT = WeightKBlockNInteger<_GemmCore_T>;
   AUTOCALL StorageWeight createStorage(const int N, const int K, int blocksize, BTLA_DTYPE fT, BTLA_DTYPE scaT) {

--- a/bestla/bestla/bestla_utils.h
+++ b/bestla/bestla/bestla_utils.h
@@ -96,6 +96,7 @@
 #define CompileAMXINT8() (CompileAMX())
 #endif
 
+// called by launcher, time critical functions
 #define TLACALL             \
   template <BTLA_ISA ISA_T> \
   static inline
@@ -103,6 +104,9 @@
 #define ISACALL             \
   template <BTLA_ISA ISA_T> \
   static
+
+// runtime auto-dispatch ISA, not time critical functions
+#define AUTOCALL static
 
 #include <immintrin.h>
 

--- a/bestla/bestla/bestla_utils.h
+++ b/bestla/bestla/bestla_utils.h
@@ -96,6 +96,14 @@
 #define CompileAMXINT8() (CompileAMX())
 #endif
 
+#define TLACALL             \
+  template <BTLA_ISA ISA_T> \
+  static inline
+
+#define ISACALL             \
+  template <BTLA_ISA ISA_T> \
+  static
+
 #include <immintrin.h>
 
 namespace bestla {

--- a/bestla/bestla/bestla_wrapper.h
+++ b/bestla/bestla/bestla_wrapper.h
@@ -456,7 +456,7 @@ class LauncherBase {
     }
   };
 
-  void run(const Param& _param, const parallel::gemm::ThreadProblemBase& _config) {
+  static void run(const Param& _param, const parallel::gemm::ThreadProblemBase& _config) {
     if (GEMVWrapper::support() && GEMVWrapper::implemented(_param)) {
       GEMVWrapper::gemv(_param, _config);
     } else {
@@ -465,7 +465,7 @@ class LauncherBase {
   }
 
  protected:
-  void gemm(const Param& _param, const parallel::gemm::ThreadProblemBase& _config) {
+  static void gemm(const Param& _param, const parallel::gemm::ThreadProblemBase& _config) {
     GemmCore::configure(_config.size[0], _config.size[1], _param.problem.dims[3]);
     auto StackTmp = alloca(_config.stacksize);
     auto tmpB = reinterpret_cast<BType*>(StackTmp);
@@ -485,8 +485,8 @@ class LauncherBase {
     }
   }
 
-  void run_block(const Param& _param, const parallel::gemm::ThreadProblemBase& _config, int blk_m, int blk_n,
-                 int blk_msize, int blk_nsize, AType* tmpA, BType* tmpB, CType* tmpC, void* tmpcache) {
+  static void run_block(const Param& _param, const parallel::gemm::ThreadProblemBase& _config, int blk_m, int blk_n,
+                        int blk_msize, int blk_nsize, AType* tmpA, BType* tmpB, CType* tmpC, void* tmpcache) {
     int n_padded = utils::padto(blk_nsize, GemmCore::NTILE);
     auto& K = _param.problem.dims[3];
     for (int iterk = 0; iterk < _param.problem.dims[3]; iterk += _config.block[2]) {
@@ -703,7 +703,7 @@ class LauncherIntKBlock {
     }
   };
 
-  void run(const Param& _param, const parallel::gemm::ThreadProblemBase& _config) {
+  static void run(const Param& _param, const parallel::gemm::ThreadProblemBase& _config) {
     if (GEMVWrapper::support() && GEMVWrapper::implemented(_param)) {
       GEMVWrapper::gemv(_param, _config);
     } else {
@@ -712,7 +712,7 @@ class LauncherIntKBlock {
   }
 
  protected:
-  void gemm(const Param& _param, const parallel::gemm::ThreadProblemBase& _config) {
+  static void gemm(const Param& _param, const parallel::gemm::ThreadProblemBase& _config) {
     GemmCore::configure(_config.size[0], _config.size[1], _param.problem.dims[3]);
     auto StackTmp = alloca(_config.stacksize);
     auto tmpB = reinterpret_cast<BType*>(StackTmp);
@@ -739,8 +739,8 @@ class LauncherIntKBlock {
 
   // _config.block[2]%kblock==0
   // _config.block[2]>=kblock
-  void run_block(const Param& _param, const parallel::gemm::ThreadProblemBase& _config, int blk_m, int blk_n,
-                 int blk_msize, int blk_nsize, AType* tmpA, BType* tmpB, AccType* tmpC, int8_t* tmpcache) {
+  static void run_block(const Param& _param, const parallel::gemm::ThreadProblemBase& _config, int blk_m, int blk_n,
+                        int blk_msize, int blk_nsize, AType* tmpA, BType* tmpB, AccType* tmpC, int8_t* tmpcache) {
     int n_padded = utils::padto(blk_nsize, GemmCore::NTILE);
     auto& K = _param.problem.dims[3];
     auto& KBlock = _param.problem.dims[4];
@@ -805,8 +805,9 @@ class LauncherIntKBlock {
   }
 
   // _config.block[2]<kblock
-  void run_largekblock(const Param& _param, const parallel::gemm::ThreadProblemBase& _config, int blk_m, int blk_n,
-                       int blk_msize, int blk_nsize, AType* tmpA, BType* tmpB, AccType* tmpC, int8_t* tmpcache) {
+  static void run_largekblock(const Param& _param, const parallel::gemm::ThreadProblemBase& _config, int blk_m,
+                              int blk_n, int blk_msize, int blk_nsize, AType* tmpA, BType* tmpB, AccType* tmpC,
+                              int8_t* tmpcache) {
     int n_padded = utils::padto(blk_nsize, GemmCore::NTILE);
     auto& K = _param.problem.dims[3];
     auto& KBlock = _param.problem.dims[4];

--- a/bestla/bestla/bestla_wrapper.h
+++ b/bestla/bestla/bestla_wrapper.h
@@ -258,12 +258,12 @@ class NBitsHelper {
 }  // namespace gemv_nbits
 
 namespace gemm {
-template <BTLA_ISA _RT_ISA_T, class _GemmCore_T, template <class _T> class _PrologueA_T,
-          template <class _T> class _PrologueB_T, class _Epilogue_T>
+template <class _GemmCore_T, template <class _T> class _PrologueA_T, template <class _T> class _PrologueB_T,
+          class _Epilogue_T>
 class LauncherBase {
  public:
   using GemmCore = _GemmCore_T;
-  static constexpr BTLA_ISA ISA = _RT_ISA_T;
+  static constexpr BTLA_ISA ISA = GemmCore::ISA;
   using PrologueA = _PrologueA_T<GemmCore>;
   using PrologueB = _PrologueB_T<GemmCore>;
   using Epilogue = _Epilogue_T;
@@ -273,14 +273,12 @@ class LauncherBase {
   using BParam = typename PrologueB::Param;
   using CType = typename GemmCore::CType;
   using EpiParam = typename Epilogue::Param;
-  static_assert(GemmCore::ISA <= _RT_ISA_T, "RunTime ISA should cover GEMM's ISA");
   struct Param {
     const utils::GemmProblem problem;
     const AParam paramA;
     const BParam paramB;
     const EpiParam paramC;
   };
-  _GemmCore_T mGemmCore;
 
   class GEMVWrapper {
    public:
@@ -384,7 +382,7 @@ class LauncherBase {
             utils::GemvParamA paramA{
                 _param.paramA.quan->template APtr<uint8_t>(), _param.paramA.quan->template SPtr<float>(),
                 _param.paramA.quan->template ZPtr<uint8_t>(), _param.paramA.quan->mKPad, _param.paramA.quan->CStep()};
-            kernel::wrapper::GEMVWoqNBits::forward_u8s8_fp32<_RT_ISA_T, ScaleT, GemmCore::NTILE, MTILE>(
+            kernel::wrapper::GEMVWoqNBits::forward_u8s8_fp32<ISA, ScaleT, GemmCore::NTILE, MTILE>(
                 paramA, paramB, tmpc_ptr, GemmCore::NTILE, k, kblocksize, StackTmp, TmpSize);
             Epilogue::Fp32Epi::template forward<ISA>(tmpc_ptr, GemmCore::NTILE, 0, _config.loc[1] + in, MTILE,
                                                      GemmCore::NTILE, _param.paramC.param2, StackTmp, TmpSize);
@@ -395,7 +393,7 @@ class LauncherBase {
                 Aptr = _param.paramA.reordered->template APtr<float>();
               }
             }
-            kernel::wrapper::GEMVWoqNBits::forward_fp32_fp32<_RT_ISA_T, ScaleT, GemmCore::NTILE, MTILE>(
+            kernel::wrapper::GEMVWoqNBits::forward_fp32_fp32<ISA, ScaleT, GemmCore::NTILE, MTILE>(
                 Aptr, _param.paramA.lda, paramB, tmpc_ptr, GemmCore::NTILE, k, kblocksize, StackTmp, TmpSize);
             Epilogue::template forward<ISA>(tmpc_ptr, GemmCore::NTILE, 0, _config.loc[1] + in, MTILE, GemmCore::NTILE,
                                             _param.paramC, StackTmp, TmpSize);
@@ -407,7 +405,7 @@ class LauncherBase {
             utils::GemvParamA paramA{
                 _param.paramA.quan->template APtr<uint8_t>(), _param.paramA.quan->template SPtr<float>(),
                 _param.paramA.quan->template ZPtr<uint8_t>(), _param.paramA.quan->mKPad, _param.paramA.quan->CStep()};
-            kernel::wrapper::GEMVWoqNBits::forward_u8s8_fp32<_RT_ISA_T, ScaleT, GemmCore::NTILE, MTILE>(
+            kernel::wrapper::GEMVWoqNBits::forward_u8s8_fp32<ISA, ScaleT, GemmCore::NTILE, MTILE>(
                 paramA, paramB, tmpc_ptr, GemmCore::NTILE, k, kblocksize, StackTmp, TmpSize);
             Epilogue::Fp32Epi::template forward<ISA>(tmpc_ptr, GemmCore::NTILE, 0, _config.loc[1] + in, MTILE,
                                                      (_config.size[1] - in), _param.paramC.param2, StackTmp, TmpSize);
@@ -418,7 +416,7 @@ class LauncherBase {
                 Aptr = _param.paramA.reordered->template APtr<float>();
               }
             }
-            kernel::wrapper::GEMVWoqNBits::forward_fp32_fp32<_RT_ISA_T, ScaleT, GemmCore::NTILE, MTILE>(
+            kernel::wrapper::GEMVWoqNBits::forward_fp32_fp32<ISA, ScaleT, GemmCore::NTILE, MTILE>(
                 Aptr, _param.paramA.lda, paramB, tmpc_ptr, GemmCore::NTILE, k, kblocksize, StackTmp, TmpSize);
             Epilogue::template forward<ISA>(tmpc_ptr, GemmCore::NTILE, 0, _config.loc[1] + in, MTILE,
                                             (_config.size[1] - in), _param.paramC, StackTmp, TmpSize);
@@ -468,7 +466,7 @@ class LauncherBase {
 
  protected:
   void gemm(const Param& _param, const parallel::gemm::ThreadProblemBase& _config) {
-    mGemmCore.configure(_config.size[0], _config.size[1], _param.problem.dims[3]);
+    GemmCore::configure(_config.size[0], _config.size[1], _param.problem.dims[3]);
     auto StackTmp = alloca(_config.stacksize);
     auto tmpB = reinterpret_cast<BType*>(StackTmp);
     tmpB = utils::cpu_pointer_align(tmpB);
@@ -509,7 +507,7 @@ class LauncherBase {
           int acache_step = 0;
           PrologueA::template getActivation<ISA>(&aptr_cache, &acache_step, _param.paramA, m_remain, k_paddedle,
                                                  (blk_m + i + _config.loc[0]), iterk, tmpcache, _config.tmpcachesize);
-          mGemmCore.forward(aptr_cache, bptr_cache, cptr_cache, m_remain, n_padded, k_paddedle,
+          GemmCore::forward(aptr_cache, bptr_cache, cptr_cache, m_remain, n_padded, k_paddedle,
                             acache_step * sizeof(AType), bcache_stride, ccache_stride, iterk, tmpcache,
                             _config.tmpcachesize);
         }
@@ -520,7 +518,7 @@ class LauncherBase {
           PrologueA::template getActivation<ISA>(&aptr_cache, &acache_step, _param.paramA, m_remain, k_tail,
                                                  (blk_m + i + _config.loc[0]), iterk + k_paddedle, tmpcache,
                                                  _config.tmpcachesize);
-          mGemmCore.forward(aptr_cache, bptr_cache + k_paddedle * GemmCore::NTILE, cptr_cache, m_remain, n_padded,
+          GemmCore::forward(aptr_cache, bptr_cache + k_paddedle * GemmCore::NTILE, cptr_cache, m_remain, n_padded,
                             GemmCore::KTILE, acache_step * sizeof(AType), bcache_stride, ccache_stride,
                             iterk + k_paddedle, tmpcache, _config.tmpcachesize);
         }
@@ -531,12 +529,12 @@ class LauncherBase {
   }
 };
 
-template <BTLA_ISA _RT_ISA_T, class _GemmCore_T, template <class _T> class _PrologueA_T,
-          template <class _T> class _PrologueB_T, class _Epilogue_T>
+template <class _GemmCore_T, template <class _T> class _PrologueA_T, template <class _T> class _PrologueB_T,
+          class _Epilogue_T>
 class LauncherIntKBlock {
  public:
   using GemmCore = _GemmCore_T;
-  static constexpr BTLA_ISA ISA = _RT_ISA_T;
+  static constexpr BTLA_ISA ISA = GemmCore::ISA;
   using PrologueA = _PrologueA_T<GemmCore>;
   using PrologueB = _PrologueB_T<GemmCore>;
   using Epilogue = _Epilogue_T;
@@ -547,14 +545,12 @@ class LauncherIntKBlock {
   using CType = typename GemmCore::CType;
   using EpiParam = typename Epilogue::Param;
   using AccType = float;
-  static_assert(GemmCore::ISA <= _RT_ISA_T, "RunTime ISA should cover GEMM's ISA");
   struct Param {
     const utils::GemmProblem problem;
     const AParam paramA;
     const BParam paramB;
     const EpiParam paramC;
   };
-  _GemmCore_T mGemmCore;
 
   class GEMVWrapper {
    public:
@@ -653,10 +649,10 @@ class LauncherIntKBlock {
         int in = 0;
         for (; in < size_padded; in += GemmCore::NTILE) {
           if constexpr (std::is_same_v<AType, uint8_t>) {
-            kernel::wrapper::GEMVWoqNBits::forward_u8s8_fp32<_RT_ISA_T, ScaleT, GemmCore::NTILE, MTILE>(
+            kernel::wrapper::GEMVWoqNBits::forward_u8s8_fp32<ISA, ScaleT, GemmCore::NTILE, MTILE>(
                 paramA, paramB, tmpc_ptr, GemmCore::NTILE, k, kblocksize, StackTmp, TmpSize);
           } else if constexpr (std::is_same_v<AType, int8_t>) {
-            kernel::wrapper::GEMVWoqNBits::forward_s8s8_fp32<_RT_ISA_T, ScaleT, GemmCore::NTILE, MTILE>(
+            kernel::wrapper::GEMVWoqNBits::forward_s8s8_fp32<ISA, ScaleT, GemmCore::NTILE, MTILE>(
                 paramA, paramB, tmpc_ptr, GemmCore::NTILE, k, kblocksize, StackTmp, TmpSize);
           }
           Epilogue::template forward<ISA>(tmpc_ptr, GemmCore::NTILE, 0, _config.loc[1] + in, MTILE, GemmCore::NTILE,
@@ -665,10 +661,10 @@ class LauncherIntKBlock {
         }
         if (size_padded != _config.size[1]) {
           if constexpr (std::is_same_v<AType, uint8_t>) {
-            kernel::wrapper::GEMVWoqNBits::forward_u8s8_fp32<_RT_ISA_T, ScaleT, GemmCore::NTILE, MTILE>(
+            kernel::wrapper::GEMVWoqNBits::forward_u8s8_fp32<ISA, ScaleT, GemmCore::NTILE, MTILE>(
                 paramA, paramB, tmpc_ptr, GemmCore::NTILE, k, kblocksize, StackTmp, TmpSize);
           } else if constexpr (std::is_same_v<AType, int8_t>) {
-            kernel::wrapper::GEMVWoqNBits::forward_s8s8_fp32<_RT_ISA_T, ScaleT, GemmCore::NTILE, MTILE>(
+            kernel::wrapper::GEMVWoqNBits::forward_s8s8_fp32<ISA, ScaleT, GemmCore::NTILE, MTILE>(
                 paramA, paramB, tmpc_ptr, GemmCore::NTILE, k, kblocksize, StackTmp, TmpSize);
           }
           Epilogue::template forward<ISA>(tmpc_ptr, GemmCore::NTILE, 0, _config.loc[1] + in, MTILE,
@@ -717,7 +713,7 @@ class LauncherIntKBlock {
 
  protected:
   void gemm(const Param& _param, const parallel::gemm::ThreadProblemBase& _config) {
-    mGemmCore.configure(_config.size[0], _config.size[1], _param.problem.dims[3]);
+    GemmCore::configure(_config.size[0], _config.size[1], _param.problem.dims[3]);
     auto StackTmp = alloca(_config.stacksize);
     auto tmpB = reinterpret_cast<BType*>(StackTmp);
     tmpB = utils::cpu_pointer_align(tmpB);
@@ -799,7 +795,7 @@ class LauncherIntKBlock {
                                        (blk_m + i + _config.loc[0]), iterk, tmp_, _config.tmpcachesize);
         PrologueA::template getScale<ISA>(&scaleA_cache, &ldsa_cache, _param.paramA, m_remain, k_padded,
                                           (blk_m + i + _config.loc[0]), iterk, tmp_, _config.tmpcachesize);
-        mGemmCore.forward(aptr_cache, bptr_cache, cptr_cache, zpA_cache, scaleA_cache, ldsa_cache, scaleB_cache,
+        GemmCore::forward(aptr_cache, bptr_cache, cptr_cache, zpA_cache, scaleA_cache, ldsa_cache, scaleB_cache,
                           reduceB_cache, ldsb_cache, m_remain, n_padded, k_padded, KBlock, acache_step * sizeof(AType),
                           bcache_stride, ccache_stride, iterk, 1.f, tmp_, _config.tmpcachesize);
       }
@@ -867,7 +863,7 @@ class LauncherIntKBlock {
           PrologueA::template getScale<ISA>(&scaleA_cache, &ldsa_cache, _param.paramA, m_remain, k_padded,
                                             (blk_m + i + _config.loc[0]), iterkk, tmp_, _config.tmpcachesize);
           auto kscale = k_remain / float(KBlock);
-          mGemmCore.forward(aptr_cache, bptr_cache, cptr_cache, zpA_cache, scaleA_cache, ldsa_cache, scaleB_cache,
+          GemmCore::forward(aptr_cache, bptr_cache, cptr_cache, zpA_cache, scaleA_cache, ldsa_cache, scaleB_cache,
                             reduceB_cache, ldsb_cache, m_remain, n_padded, k_padded, k_padded,
                             acache_step * sizeof(AType), bcache_stride, ccache_stride, iterkk, kscale, tmp_,
                             _config.tmpcachesize);

--- a/bestla/bestla/kernel_avx512f.h
+++ b/bestla/bestla/kernel_avx512f.h
@@ -2608,7 +2608,7 @@ template <int PackRow, int NTILE>
 inline BTLA_CODE decompress_kblock_s4_s8(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                          int n_offset, int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::int4x2 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -2830,7 +2830,7 @@ static inline BTLA_CODE decompress_kblock_s2_s8(utils::bit2x4* bit2ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -3088,7 +3088,7 @@ static inline BTLA_CODE decompress_kblock_s3_s8(utils::bit2x4* bit2ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -3310,7 +3310,7 @@ static inline BTLA_CODE decompress_kblock_s1_s8(utils::bit1x8* bit1ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -3559,7 +3559,7 @@ static inline BTLA_CODE decompress_kblock_s5_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -3873,9 +3873,9 @@ static inline BTLA_CODE decompress_kblock_s7_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset,
                                                 int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
-                                    int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
-                                    int row, int8_t* tmp, size_t tmpsize);
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr,
+                                    int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp, int n_offset,
+                                    int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
       if constexpr (PackRow == 1) {
@@ -4144,7 +4144,7 @@ static inline BTLA_CODE decompress_kblock_s6_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, int8_t* zpptr, int8_t* dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, int8_t * zpptr, int8_t * dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;

--- a/bestla/bestla/kernel_avx512f.h
+++ b/bestla/bestla/kernel_avx512f.h
@@ -1159,7 +1159,7 @@ constexpr auto broadcast_F4_E2M1_quantv = broadcast_N_2_Nx16<8>(F4_E2M1_simd_qua
 
 template <BTLA_DTYPE F4_T>
 inline BTLA_CODE quantize_f32_f4_rowblock(const float* srcptr, int8_t* dstptr, int row, int col, int ld_src, int ld_dst,
-                                          float* scales, int8_t* zero_points, int blocksize) {
+                                          float* scales, int blocksize) {
   // assert(col % 16 == 0);
   auto align_row = row / blocksize * blocksize;
   auto align_blk = blocksize / 4 * 4;
@@ -2608,7 +2608,7 @@ template <int PackRow, int NTILE>
 inline BTLA_CODE decompress_kblock_s4_s8(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                          int n_offset, int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::int4x2 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::int4x2* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -2830,7 +2830,7 @@ static inline BTLA_CODE decompress_kblock_s2_s8(utils::bit2x4* bit2ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * srcptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* srcptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -3088,7 +3088,7 @@ static inline BTLA_CODE decompress_kblock_s3_s8(utils::bit2x4* bit2ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -3310,7 +3310,7 @@ static inline BTLA_CODE decompress_kblock_s1_s8(utils::bit1x8* bit1ptr, int8_t* 
                                                 int ldzp, int n_offset, int k_offset, int row, int col, int8_t* tmp,
                                                 size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp,
+    typedef BTLA_CODE (*decompfunc)(utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp,
                                     int n_offset, int k_offset, int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
@@ -3559,7 +3559,7 @@ static inline BTLA_CODE decompress_kblock_s5_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit1x8 * bit1ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit1x8* bit1ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;
@@ -3873,9 +3873,9 @@ static inline BTLA_CODE decompress_kblock_s7_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset,
                                                 int k_offset, int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, utils::bit1x8 * bit1ptr,
-                                    int8_t * zpptr, int8_t * dstptr, int blocksize, int ldzp, int n_offset,
-                                    int k_offset, int row, int8_t* tmp, size_t tmpsize);
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
+                                    int8_t* zpptr, int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
+                                    int row, int8_t* tmp, size_t tmpsize);
     decompfunc func = nullptr;
     if (col == NTILE) {
       if constexpr (PackRow == 1) {
@@ -4144,7 +4144,7 @@ static inline BTLA_CODE decompress_kblock_s6_s8(utils::bit4x2* bit4ptr, utils::b
                                                 int8_t* dstptr, int blocksize, int ldzp, int n_offset, int k_offset,
                                                 int row, int col, int8_t* tmp, size_t tmpsize) {
   if (zpptr) {
-    typedef BTLA_CODE (*decompfunc)(utils::bit4x2 * bit4ptr, utils::bit2x4 * bit2ptr, int8_t * zpptr, int8_t * dstptr,
+    typedef BTLA_CODE (*decompfunc)(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, int8_t* zpptr, int8_t* dstptr,
                                     int blocksize, int ldzp, int n_offset, int k_offset, int row, int8_t* tmp,
                                     size_t tmpsize);
     decompfunc func = nullptr;

--- a/bestla/bestla/kernel_avx512f.h
+++ b/bestla/bestla/kernel_avx512f.h
@@ -3601,7 +3601,7 @@ static inline BTLA_CODE decompress_s7_s8(utils::bit4x2* bit4ptr, utils::bit2x4* 
                                          int8_t* dstptr, size_t unpack_elt, int8_t* tmp, size_t tmpsize) {
   int constexpr VBits = 512;
   int constexpr VElt = VBits / 8;
-  int i = 0;
+  size_t i = 0;
   int constexpr FullRange = 1 << (7 - 1);
   uint32_t mask = 0x0f0f0f0f;
   auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));
@@ -3916,7 +3916,7 @@ static inline BTLA_CODE decompress_s6_s8(utils::bit4x2* bit4ptr, utils::bit2x4* 
                                          size_t unpack_elt, int8_t* tmp, size_t tmpsize) {
   int constexpr VBits = 512;
   int constexpr VElt = VBits / 8;
-  int i = 0;
+  size_t i = 0;
   int constexpr FullRange = 1 << (6 - 1);
   uint32_t mask = 0x0f0f0f0f;
   auto vmask = _mm512_set1_epi32(*reinterpret_cast<int*>(&mask));

--- a/bestla/bestla/kernel_ref.h
+++ b/bestla/bestla/kernel_ref.h
@@ -409,8 +409,8 @@ static inline void convert_s4_s8_8(int8_t* dstptr, int8_t* srcptr) {
   dstptr[7] = static_cast<int8_t>(tmp);
 }
 
-static inline BTLA_CODE decompress_s6_s8(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, int8_t* dstptr, int unpack_elt,
-                                         int8_t* tmp, size_t tmpsize) {
+static inline BTLA_CODE decompress_s6_s8(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, int8_t* dstptr,
+                                         size_t unpack_elt, int8_t* tmp, size_t tmpsize) {
   int constexpr FullRange = 1 << (6 - 1);
   for (size_t i = 0; i < unpack_elt; i += 4) {
     auto bit2 = bit2ptr[i / 4];
@@ -424,8 +424,8 @@ static inline BTLA_CODE decompress_s6_s8(utils::bit4x2* bit4ptr, utils::bit2x4* 
   return BTLA_CODE::Success;
 }
 
-static inline BTLA_CODE decompress_s5_s8(utils::bit4x2* bit4ptr, utils::bit1x8* bit1ptr, int8_t* dstptr, int unpack_elt,
-                                         int8_t* tmp, size_t tmpsize) {
+static inline BTLA_CODE decompress_s5_s8(utils::bit4x2* bit4ptr, utils::bit1x8* bit1ptr, int8_t* dstptr,
+                                         size_t unpack_elt, int8_t* tmp, size_t tmpsize) {
   int constexpr FullRange = 1 << (5 - 1);
   for (size_t i = 0; i < unpack_elt; i += 8) {
     auto bit1 = bit1ptr[i / 8];
@@ -446,7 +446,7 @@ static inline BTLA_CODE decompress_s5_s8(utils::bit4x2* bit4ptr, utils::bit1x8* 
 }
 
 static inline BTLA_CODE decompress_s7_s8(utils::bit4x2* bit4ptr, utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr,
-                                         int8_t* dstptr, int unpack_elt, int8_t* tmp, size_t tmpsize) {
+                                         int8_t* dstptr, size_t unpack_elt, int8_t* tmp, size_t tmpsize) {
   int constexpr FullRange = 1 << (7 - 1);
   for (size_t i = 0; i < unpack_elt; i += 8) {
     auto bit2 = bit2ptr[i / 4];
@@ -478,8 +478,8 @@ static inline BTLA_CODE decompress_s4_s8(utils::int4x2* srcptr, int8_t* dstptr, 
   return BTLA_CODE::Success;
 }
 
-static inline BTLA_CODE decompress_s3_s8(utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr, int8_t* dstptr, int unpack_elt,
-                                         int8_t* tmp, size_t tmpsize) {
+static inline BTLA_CODE decompress_s3_s8(utils::bit2x4* bit2ptr, utils::bit1x8* bit1ptr, int8_t* dstptr,
+                                         size_t unpack_elt, int8_t* tmp, size_t tmpsize) {
   for (size_t i = 0; i < unpack_elt; i += 8) {
     auto bit1 = bit1ptr[i / 8];
     auto tmp = bit2ptr[i / 4];
@@ -508,7 +508,7 @@ static inline BTLA_CODE decompress_s2_s8(utils::bit2x4* srcptr, int8_t* dstptr, 
   return BTLA_CODE::Success;
 }
 
-static inline BTLA_CODE decompress_s1_s8(utils::bit1x8* bit1ptr, int8_t* dstptr, int unpack_elt, int8_t* tmp,
+static inline BTLA_CODE decompress_s1_s8(utils::bit1x8* bit1ptr, int8_t* dstptr, size_t unpack_elt, int8_t* tmp,
                                          size_t tmpsize) {
   int8_t constexpr FullRange = 1 << (1 - 1);
   for (size_t i = 0; i < unpack_elt; i += 8) {
@@ -991,7 +991,7 @@ static inline float f8_to_fp32(utils::f8 v, BTLA_DTYPE f8_t) {
   auto mantissabit = 7 - ebits;
   e_revert &= 0x7f;
   e_revert >>= mantissabit;
-  e_revert = e_revert - std::pow(2, ebits - 1) + 1 + 127;
+  e_revert = e_revert - std::powf(2, ebits - 1) + 1 + 127;
   e_revert <<= 23;
   mantissa_revert <<= (23 - mantissabit);
   mantissa_revert &= 0x007fffff;
@@ -1012,7 +1012,7 @@ static inline BTLA_CODE decompress_kblock_f8_fp(utils::f8* srcptr, _DST_T* dstpt
       float scale;
       if constexpr (std::is_same_v<_S_T, utils::f8>) {
         int shared_exp = sptr[j / _PACK_ROW].x;
-        scale = std::pow(2, shared_exp);
+        scale = std::powf(2, shared_exp);
       } else if constexpr (std::is_same_v<_S_T, float>) {
         scale = scales[j / _PACK_ROW];
       } else {
@@ -1037,7 +1037,7 @@ inline BTLA_CODE decompress_kblock_s8_fp(int8_t* srcptr, DST_T* dstptr, int row,
         auto zp = zero_points ? zero_points[kpos + j] : 0;
         for (int ir = 0; ir < PackRow; ir++) {
           float tmp = static_cast<float>(srcptr[i * col + j * PackRow + ir] - zp) * scale;
-          dstptr[i * col + j * PackRow + ir] = tmp;
+          dstptr[i * col + j * PackRow + ir] = static_cast<DST_T>(tmp);
         }
       }
     } else if (sdtype == BTLA_DTYPE::BF16) {
@@ -1047,7 +1047,7 @@ inline BTLA_CODE decompress_kblock_s8_fp(int8_t* srcptr, DST_T* dstptr, int row,
         auto zp = zero_points ? zero_points[kpos + j] : 0;
         for (int ir = 0; ir < PackRow; ir++) {
           float tmp = static_cast<float>(srcptr[i * col + j * PackRow + ir] - zp) * scale;
-          dstptr[i * col + j * PackRow + ir] = tmp;
+          dstptr[i * col + j * PackRow + ir] = static_cast<DST_T>(tmp);
         }
       }
     }
@@ -1233,7 +1233,7 @@ static inline float fp4_bnb_dequantize(uint8_t val, float absmax) { return fp4_b
 
 static inline int8_t fp4_bnb_quantize(float x) {
   int sign = x < 0 ? 0b1000 : 0b0000;
-  x = fabsf(x);
+  x = fabs(x);
   if (x > 0.29166667f)
     if (x > 0.583333f)
       if (x > 0.8333333f)
@@ -1269,7 +1269,7 @@ static inline int8_t fp4_e2m1_quantize(float x) {
   // 0b111 = 6
 
   int sign = x < 0 ? 0b1000 : 0b0000;
-  x = fabsf(x);
+  x = fabs(x);
   if (x > 1.75f / 6) {
     if (x > 3.5f / 6) {
       if (x > 5.f / 6)
@@ -1599,7 +1599,7 @@ static inline BTLA_CODE get2d_e8m0_scale(const void* srcptr, void* dstptr, int r
   auto col_elt = col / sizeof(utils::f8);
   for (int i = 0; i < row; i++) {
     for (int j = 0; j < col_elt; j++) {
-      f32_v[i * f32_stride + j] = std::pow(2, f8_v[i * f8_stride + j].x);
+      f32_v[i * f32_stride + j] = std::powf(2, f8_v[i * f8_stride + j].x);
     }
   }
   return BTLA_CODE::Success;
@@ -1722,23 +1722,23 @@ static inline BTLA_CODE quantize_f32_sign_int_rowblock(const float* srcptr, int8
 template <BTLA_DTYPE F8_T>
 static inline int8_t f8_mx_quantize(float v, float scale, BTLA_DTYPE scale_dtype) {
   if (scale_dtype == BTLA_DTYPE::F8_E8M0) {
-    v /= std::pow(2, scale);
+    v /= std::powf(2, scale);
   } else {
     v /= scale;
   }
   auto ebits = utils::bestla_dtype_get_f8_ebits(F8_T);
   auto quant_mantissa = utils::bestla_dtype_get_f8_quant_mbits(F8_T);
   auto store_mantissa = 7 - ebits;
-  auto private_exp = std::floor(std::log2(std::abs(v == 0 ? v + 1 : v)));
-  auto min_exp = -1 * (std::pow(2, ebits - 1)) + 2;
+  auto private_exp = std::floorf(std::log2(std::abs(v == 0 ? v + 1 : v)));
+  auto min_exp = -1 * (std::powf(2, ebits - 1)) + 2;
   private_exp = private_exp < min_exp ? min_exp : private_exp;
 
   // Scale up so appropriate number of bits are in the integer portion of the number
-  v = v / std::pow(2, private_exp) * std::pow(2, quant_mantissa - 2);
+  v = v / std::powf(2, private_exp) * std::powf(2, quant_mantissa - 2);
   auto sign = v > 0 ? 1 : -1;
-  v = sign * std::floor(std::abs(v) + 0.5);
+  v = sign * std::floorf(std::abs(v) + 0.5);
   // Undo scaling
-  v = v / std::pow(2, quant_mantissa - 2) * std::pow(2, private_exp);
+  v = v / std::powf(2, quant_mantissa - 2) * std::powf(2, private_exp);
 
   // saturate normals.
   auto max_norm = utils::get_mxfp_maxnorm(F8_T, ebits, quant_mantissa);
@@ -1749,7 +1749,7 @@ static inline int8_t f8_mx_quantize(float v, float scale, BTLA_DTYPE scale_dtype
   uint8_t store_signbit = (*(p + 3) & 0x80);
   *shift_v <<= 1;
   uint8_t store_ebit = (*(p + 3) & 0xFF);
-  store_ebit = store_ebit - 127 + std::pow(2, ebits - 1) - 1;
+  store_ebit = store_ebit - 127 + std::powf(2, ebits - 1) - 1;
   if (store_ebit > 15 && F8_T == BTLA_DTYPE::F8_E4M3) store_ebit = 0;
   if (store_ebit > 31 && F8_T == BTLA_DTYPE::F8_E5M2) store_ebit = 0;
   store_ebit <<= store_mantissa;
@@ -1777,10 +1777,10 @@ static inline BTLA_CODE quantize_f32_f8_rowblock_mxscale(const float* srcptr, in
         if (scale == 0) scale += std::abs(std::numeric_limits<float>::min());
         scale = std::floor(std::log2(scale));
         auto ebits = utils::bestla_dtype_get_f8_ebits(F8_T);
-        auto emax = std::pow(2, ebits - 1);
+        auto emax = std::powf(2, ebits - 1);
         if (F8_T == BTLA_DTYPE::F8_E5M2) emax -= 1;
         scale -= emax;
-        auto scale_max = std::pow(2, 7) - 1;  // e8m0 scale type.
+        auto scale_max = std::powf(2, 7) - 1;  // e8m0 scale type.
         scale = scale < (-1 * scale_max) ? (-1 * scale_max) : scale;
       } else if (scale_dtype == BTLA_DTYPE::F32) {
         scale /= utils::get_mxfp_maxnorm(F8_T, utils::bestla_dtype_get_f8_ebits(F8_T),
@@ -2019,7 +2019,7 @@ static inline BTLA_CODE accum_alphaN_f32_f32(const SCA_T* alpha, const float* sr
         dstptr[i * dststep + j] = static_cast<float>(alpha[j]) * srcptr[i * srcstep + j] + dstptr[i * dststep + j];
       } else {
         dstptr[i * dststep + j] =
-            std::pow(2, alpha[j].x) * srcptr[i * srcstep + j] + dstptr[i * dststep + j];  // e8m0 scale.
+            std::powf(2, alpha[j].x) * srcptr[i * srcstep + j] + dstptr[i * dststep + j];  // e8m0 scale.
       }
     }
   }
@@ -2258,7 +2258,7 @@ inline float exp_ps_0_1(float x) {
   const float z = std::floor(x1);
   const float f = x1 - z;
   constexpr std::array<float, 3> coeff{0.240226507f, 0.452920674f, 0.713483036f};
-  // same as a * std::pow(2, z) but more precise
+  // same as a * std::powf(2, z) but more precise
   return ldexpf(coeff[0] * f * f + coeff[1] * f + coeff[2], static_cast<int>(z));
 }
 

--- a/bestla/bestla/kernel_wrapper.h
+++ b/bestla/bestla/kernel_wrapper.h
@@ -105,18 +105,20 @@ class Memcpy2D {
       }
     }
     if constexpr (utils::isa_base<ISA_T>::avx2) {
-      auto align_col = col * sizeof(_SRC_T) / 32 * 32 / sizeof(_SRC_T);
+      auto align_col = static_cast<int>(col * sizeof(_SRC_T) / 32 * 32 / sizeof(_SRC_T));
       ret = kernel::jit::JitMemcpy2DAvx2::forward<_SRC_T, _DST_T>(srcptr, dstptr, row, align_col, srcstep, dststep,
                                                                   const_elt_v);
       if (col - align_col > 0)
-        ret = kernel::ref::memcpy2d(srcptr + align_col, dstptr + align_col, row, (col - align_col) * sizeof(_SRC_T),
-                                    srcstep * sizeof(_SRC_T), dststep * sizeof(_DST_T));
+        ret = kernel::ref::memcpy2d(
+            srcptr + align_col, dstptr + align_col, row, static_cast<int>((col - align_col) * sizeof(_SRC_T)),
+            static_cast<int>(srcstep * sizeof(_SRC_T)), static_cast<int>(dststep * sizeof(_DST_T)));
       if (ret == BTLA_CODE::Success) {
         return ret;
       }
     }
-    return kernel::ref::memcpy2d(srcptr, dstptr, row, col * sizeof(_SRC_T), srcstep * sizeof(_SRC_T),
-                                 dststep * sizeof(_DST_T));
+    return kernel::ref::memcpy2d(srcptr, dstptr, row, static_cast<int>(col * sizeof(_SRC_T)),
+                                 static_cast<int>(srcstep * sizeof(_SRC_T)),
+                                 static_cast<int>(dststep * sizeof(_DST_T)));
   }
 
   template <BTLA_ISA ISA_T, typename _SRC_T, typename _DST_T, BTLA_ELTWISEOP OP_T>
@@ -131,13 +133,13 @@ class Memcpy2D {
       }
     }
     if constexpr (utils::isa_base<ISA_T>::avx2) {
-      auto align_col = col * sizeof(_SRC_T) / 32 * 32 / sizeof(_SRC_T);
+      auto align_col = static_cast<int>(col * sizeof(_SRC_T) / 32 * 32 / sizeof(_SRC_T));
       ret = kernel::jit::JitMemcpy2DAvx2::forward1<_SRC_T, _DST_T, OP_T>(srcptr, dstptr, row, align_col, srcstep,
                                                                          dststep, const_elt_v);
       if (col - align_col > 0)
         ret = kernel::ref::memcpy2d_withop<_SRC_T, _DST_T, OP_T>(
-            srcptr + align_col, dstptr + align_col, row, (col - align_col) * sizeof(_SRC_T), srcstep * sizeof(_SRC_T),
-            dststep * sizeof(_DST_T), const_elt_v);
+            srcptr + align_col, dstptr + align_col, row, static_cast<int>((col - align_col) * sizeof(_SRC_T)),
+            static_cast<int>(srcstep * sizeof(_SRC_T)), static_cast<int>(dststep * sizeof(_DST_T)), const_elt_v);
       if (ret == BTLA_CODE::Success) {
         return ret;
       }
@@ -368,7 +370,7 @@ class CompressBit1 {
 template <typename _T>
 class Transpose2D {
  public:
-  TLACALL inline BTLA_CODE forward(const _T* srcptr, _T* dstptr, int row, int col, int ld_src, int ld_dst) {
+  TLACALL BTLA_CODE forward(const _T* srcptr, _T* dstptr, int row, int col, int ld_src, int ld_dst) {
     return ref::transpose2d(srcptr, dstptr, row, col, ld_src, ld_dst);
   }
 

--- a/bestla/bestla/ut/bestla_benchmark.cpp
+++ b/bestla/bestla/ut/bestla_benchmark.cpp
@@ -21,20 +21,19 @@ class Benchmark_Fp32Fp32 {
   void benchmark(int m, int n, int k, int batch, AType* A, BType* B, CType* C, float timems, int threads) {
     LOG_T log;
     using Parallel = parallel::gemm::SchedulerBase<Core_T>;
-    using Launcher =
-        wrapper::gemm::LauncherBase<Core_T::ISA, Core_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
-                                    epilogue::gemm::AccumulatorWriteBackFp32>;
-    Launcher kernel;
+    using Launcher = wrapper::gemm::LauncherBase<Core_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
+                                                 epilogue::gemm::AccumulatorWriteBackFp32>;
+
     UT_Threading::set_threads(threads);
     auto corestr = gemm::CoreAttr::to_str(Core_T::ID);
     utils::timer<std::chrono::milliseconds> tm;
-    auto tmpB = kernel.mProB.createStorage(n, k);
+    auto tmpB = Launcher::PrologueB::createStorage(n, k);
     std::vector<storage::gemm::StoragePackedWeight> packBs(batch, 0);
     avector<int8_t> bufB(tmpB.mSize * batch);
     for (size_t i = 0; i < batch; i++) {
       packBs[i] = tmpB;
       packBs[i].assign(bufB.data() + i * tmpB.mSize);
-      kernel.mProB.packWeight(n, k, {B + i * n * k, n, &packBs[i]}, UT_Threading::get());
+      Launcher::PrologueB::packWeight(n, k, {B + i * n * k, n, &packBs[i]}, UT_Threading::get());
     }
     auto psize = (size_t)m * n * k * 2;
     tm.start();
@@ -43,7 +42,7 @@ class Benchmark_Fp32Fp32 {
         log.start();
         utils::GemmProblem gp(1, m, n, k);
         typename Launcher::Param args{gp, {A + i * m * k, k}, {0, 0, &packBs[i]}, {C + i * m * n, n}};
-        parallel::GemmRun<Parallel>(kernel, args, UT_Threading::get());
+        parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
         log.stop();
         if (tm.stop() >= timems) {
           break;
@@ -103,20 +102,18 @@ class Benchmark_U8S8S32 {
   void benchmark(int m, int n, int k, int batch, AType* A, BType* B, CType* C, float timems, int threads) {
     LOG_T log;
     using Parallel = parallel::gemm::SchedulerBase<Core_T>;
-    using Launcher =
-        wrapper::gemm::LauncherBase<Core_T::ISA, Core_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
-                                    epilogue::gemm::AccumulatorWriteBackInt32>;
-    static Launcher kernel;
+    using Launcher = wrapper::gemm::LauncherBase<Core_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
+                                                 epilogue::gemm::AccumulatorWriteBackInt32>;
     UT_Threading::set_threads(threads);
     auto corestr = gemm::CoreAttr::to_str(Core_T::ID);
     utils::timer<std::chrono::milliseconds> tm;
-    auto tmpB = kernel.mProB.createStorage(n, k);
+    auto tmpB = Launcher::PrologueB::createStorage(n, k);
     std::vector<storage::gemm::StoragePackedWeight> packBs(batch, 0);
     avector<int8_t> bufB(tmpB.mSize * batch);
     for (size_t i = 0; i < batch; i++) {
       packBs[i] = tmpB;
       packBs[i].assign(bufB.data() + i * tmpB.mSize);
-      kernel.mProB.packWeight(n, k, {B + i * n * k, n, &packBs[i]}, UT_Threading::get());
+      Launcher::PrologueB::packWeight(n, k, {B + i * n * k, n, &packBs[i]}, UT_Threading::get());
     }
     auto psize = (size_t)m * n * k * 2;
     tm.start();
@@ -125,7 +122,7 @@ class Benchmark_U8S8S32 {
         log.start();
         utils::GemmProblem gp(1, m, n, k);
         typename Launcher::Param args{gp, {A + i * m * k, k}, {0, 0, &packBs[i]}, {C + i * m * n, n}};
-        parallel::GemmRun<Parallel>(kernel, args, UT_Threading::get());
+        parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
         log.stop();
         if (tm.stop() >= timems) {
           break;
@@ -197,20 +194,19 @@ class Benchmark_S8S8S32 {
   void benchmark(int m, int n, int k, int batch, AType* A, BType* B, CType* C, float timems, int threads) {
     LOG_T log;
     using Parallel = parallel::gemm::SchedulerBase<Core_T>;
-    using Launcher =
-        wrapper::gemm::LauncherBase<Core_T::ISA, Core_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
-                                    epilogue::gemm::AccumulatorWriteBackInt32>;
-    Launcher kernel;
+    using Launcher = wrapper::gemm::LauncherBase<Core_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
+                                                 epilogue::gemm::AccumulatorWriteBackInt32>;
+
     UT_Threading::set_threads(threads);
     auto corestr = gemm::CoreAttr::to_str(Core_T::ID);
     utils::timer<std::chrono::milliseconds> tm;
-    auto tmpB = kernel.mProB.createStorage(n, k);
+    auto tmpB = Launcher::PrologueB::createStorage(n, k);
     std::vector<storage::gemm::StoragePackedWeight> packBs(batch, 0);
     avector<int8_t> bufB(tmpB.mSize * batch);
     for (size_t i = 0; i < batch; i++) {
       packBs[i] = tmpB;
       packBs[i].assign(bufB.data() + i * tmpB.mSize);
-      kernel.mProB.packWeight(n, k, {B + i * n * k, n, &packBs[i]}, UT_Threading::get());
+      Launcher::PrologueB::packWeight(n, k, {B + i * n * k, n, &packBs[i]}, UT_Threading::get());
     }
     auto psize = (size_t)m * n * k * 2;
     tm.start();
@@ -219,7 +215,7 @@ class Benchmark_S8S8S32 {
         log.start();
         utils::GemmProblem gp(1, m, n, k);
         typename Launcher::Param args{gp, {A + i * m * k, k}, {0, 0, &packBs[i]}, {C + i * m * n, n}};
-        parallel::GemmRun<Parallel>(kernel, args, UT_Threading::get());
+        parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
         log.stop();
         if (tm.stop() >= timems) {
           break;
@@ -291,20 +287,19 @@ class Benchmark_Bf16Bf16Fp32 {
   void benchmark(int m, int n, int k, int batch, AType* A, BType* B, CType* C, float timems, int threads) {
     LOG_T log;
     using Parallel = parallel::gemm::SchedulerBase<Core_T>;
-    using Launcher =
-        wrapper::gemm::LauncherBase<Core_T::ISA, Core_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
-                                    epilogue::gemm::AccumulatorWriteBackFp32>;
-    Launcher kernel;
+    using Launcher = wrapper::gemm::LauncherBase<Core_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
+                                                 epilogue::gemm::AccumulatorWriteBackFp32>;
+
     UT_Threading::set_threads(threads);
     auto corestr = gemm::CoreAttr::to_str(Core_T::ID);
     utils::timer<std::chrono::milliseconds> tm;
-    auto tmpB = kernel.mProB.createStorage(n, k);
+    auto tmpB = Launcher::PrologueB::createStorage(n, k);
     std::vector<storage::gemm::StoragePackedWeight> packBs(batch, 0);
     avector<int8_t> bufB(tmpB.mSize * batch);
     for (size_t i = 0; i < batch; i++) {
       packBs[i] = tmpB;
       packBs[i].assign(bufB.data() + i * tmpB.mSize);
-      kernel.mProB.packWeight(n, k, {B + i * n * k, n, &packBs[i]}, UT_Threading::get());
+      Launcher::PrologueB::packWeight(n, k, {B + i * n * k, n, &packBs[i]}, UT_Threading::get());
     }
     auto psize = (size_t)m * n * k * 2;
     tm.start();
@@ -313,7 +308,7 @@ class Benchmark_Bf16Bf16Fp32 {
         log.start();
         utils::GemmProblem gp(1, m, n, k);
         typename Launcher::Param args{gp, {A + i * m * k, k}, {0, 0, &packBs[i]}, {C + i * m * n, n}};
-        parallel::GemmRun<Parallel>(kernel, args, UT_Threading::get());
+        parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
         log.stop();
         if (tm.stop() >= timems) {
           break;
@@ -372,20 +367,19 @@ class Benchmark_Fp16Fp16Fp16 {
   void benchmark(int m, int n, int k, int batch, AType* A, BType* B, CType* C, float timems, int threads) {
     LOG_T log;
     using Parallel = parallel::gemm::SchedulerBase<Core_T>;
-    using Launcher =
-        wrapper::gemm::LauncherBase<Core_T::ISA, Core_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
-                                    epilogue::gemm::AccumulatorWriteBackFp16>;
-    Launcher kernel;
+    using Launcher = wrapper::gemm::LauncherBase<Core_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
+                                                 epilogue::gemm::AccumulatorWriteBackFp16>;
+
     UT_Threading::set_threads(threads);
     auto corestr = gemm::CoreAttr::to_str(Core_T::ID);
     utils::timer<std::chrono::milliseconds> tm;
-    auto tmpB = kernel.mProB.createStorage(n, k);
+    auto tmpB = Launcher::PrologueB::createStorage(n, k);
     std::vector<storage::gemm::StoragePackedWeight> packBs(batch, 0);
     avector<int8_t> bufB(tmpB.mSize * batch);
     for (size_t i = 0; i < batch; i++) {
       packBs[i] = tmpB;
       packBs[i].assign(bufB.data() + i * tmpB.mSize);
-      kernel.mProB.packWeight(n, k, {B + i * n * k, n, &packBs[i]}, UT_Threading::get());
+      Launcher::PrologueB::packWeight(n, k, {B + i * n * k, n, &packBs[i]}, UT_Threading::get());
     }
     auto psize = (size_t)m * n * k * 2;
     tm.start();
@@ -394,7 +388,7 @@ class Benchmark_Fp16Fp16Fp16 {
         log.start();
         GemmProblem gp(1, m, n, k);
         typename Launcher::Param args{gp, {A + i * m * k, k}, {0, 0, &packBs[i]}, {C + i * m * n, n}};
-        parallel::GemmRun<Parallel>(kernel, args, UT_Threading::get());
+        parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
         log.stop();
         if (tm.stop() >= timems) {
           break;
@@ -475,26 +469,25 @@ class UTWOQ_CompFp32 {
     benchmark_all<prologue_b::gemm::WeightKBlockNFloat, utils::bf16>(1024, 4096, 4096, BTLA_DTYPE::F4_BNB);
   }
 
-  template <typename Core_T, typename LOG_T, template <class _T, BTLA_ISA> class Wei, typename Scale_T>
+  template <typename Core_T, typename LOG_T, template <class _T> class Wei, typename Scale_T>
   void benchmark(int m, int n, int k, int batch, int blocksize, float* A, float* B, float* C, float timems, int threads,
                  BTLA_DTYPE qtype, bool isasym) {
     LOG_T log;
     using Parallel = parallel::gemm::SchedulerBase<Core_T>;
-    using Launcher = wrapper::gemm::LauncherBase<Core_T::ISA, Core_T, prologue_a::gemm::ActivationBase, Wei,
+    using Launcher = wrapper::gemm::LauncherBase<Core_T, prologue_a::gemm::ActivationBase, Wei,
                                                  epilogue::gemm::AccumulatorWriteBackFp32>;
-    Launcher kernel;
+
     UT_Threading::set_threads(threads);
     auto corestr = gemm::CoreAttr::to_str(Core_T::ID);
     utils::timer<std::chrono::milliseconds> tm;
-    using WType = typename Wei<Core_T, Core_T::ISA>::StorageWeight;
+    using WType = typename Wei<Core_T>::StorageWeight;
     WType tmpB(0);
-    if constexpr (std::is_same_v<Wei<Core_T, Core_T::ISA>,
-                                 prologue_b::gemm::WeightKBlockNInteger<Core_T, Core_T::ISA>>) {
-      tmpB = kernel.mProB.createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>, bestla_dtype<float>, isasym);
+    if constexpr (std::is_same_v<Wei<Core_T>, prologue_b::gemm::WeightKBlockNInteger<Core_T>>) {
+      tmpB = Launcher::PrologueB::createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>, bestla_dtype<float>,
+                                                isasym);
 
-    } else if constexpr (std::is_same_v<Wei<Core_T, Core_T::ISA>,
-                                        prologue_b::gemm::WeightKBlockNFloat<Core_T, Core_T::ISA>>) {
-      tmpB = kernel.mProB.createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>);
+    } else if constexpr (std::is_same_v<Wei<Core_T>, prologue_b::gemm::WeightKBlockNFloat<Core_T>>) {
+      tmpB = Launcher::PrologueB::createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>);
     }
     std::vector<WType> packBs(batch, 0);
     avector<int8_t> bufB(tmpB.mSize * batch);
@@ -502,7 +495,7 @@ class UTWOQ_CompFp32 {
       packBs[i] = tmpB;
       packBs[i].assign(bufB.data() + i * tmpB.mSize);
     }
-    kernel.mProB.packWeight(n, k, B, n, &packBs[0], UT_Threading::get());
+    Launcher::PrologueB::packWeight(n, k, B, n, &packBs[0], UT_Threading::get());
     for (size_t i = 1; i < batch; i++) {
       memcpy(packBs[i].template WPtr<void>(), packBs[0].template WPtr<void>(), packBs[0].template WSize<char>());
       memcpy(packBs[i].template SPtr<void>(), packBs[0].template SPtr<void>(), packBs[0].CSize() * sizeof(Scale_T));
@@ -517,7 +510,7 @@ class UTWOQ_CompFp32 {
         log.start();
         GemmProblem gp(1, m, n, k, blocksize);
         typename Launcher::Param args{gp, {A + i * m * k, k}, {&packBs[i]}, {C + i * m * n, n}};
-        parallel::GemmRun<Parallel>(kernel, args, UT_Threading::get());
+        parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
         log.stop();
         if (tm.stop() >= timems) {
           break;
@@ -532,7 +525,7 @@ class UTWOQ_CompFp32 {
            corestr, log.get_log_str(), flops, flops / cores, band);
   }
 
-  template <template <class _T, BTLA_ISA> class Wei, typename Scale_T>
+  template <template <class _T> class Wei, typename Scale_T>
   void benchmark_all(int m, int n, int k, BTLA_DTYPE qtype, bool isasym = false) {
     auto memsize = gemm_memsize(m, n, k, BTLA_DTYPE::F32, qtype, BTLA_DTYPE::F32);
     int batch = auto_batch(memsize);
@@ -595,26 +588,25 @@ class UTWOQ_CompBf16 {
     benchmark_all<prologue_b::gemm::WeightKBlockNFloat, utils::bf16>(2048, 4096, 4096, BTLA_DTYPE::F4_BNB);
   }
 
-  template <typename Core_T, typename LOG_T, template <class _T, BTLA_ISA> class Wei, typename Scale_T>
+  template <typename Core_T, typename LOG_T, template <class _T> class Wei, typename Scale_T>
   void benchmark(int m, int n, int k, int batch, int blocksize, float* A, float* B, float* C, float timems, int threads,
                  BTLA_DTYPE qtype) {
     LOG_T log;
     using Parallel = parallel::gemm::SchedulerBase<Core_T>;
-    using Launcher = wrapper::gemm::LauncherBase<Core_T::ISA, Core_T, prologue_a::gemm::ActivationConverterFp32, Wei,
+    using Launcher = wrapper::gemm::LauncherBase<Core_T, prologue_a::gemm::ActivationConverterFp32, Wei,
                                                  epilogue::gemm::AccumulatorWriteBackFp32>;
-    Launcher kernel;
+
     UT_Threading::set_threads(threads);
     auto corestr = gemm::CoreAttr::to_str(Core_T::ID);
     utils::timer<std::chrono::milliseconds> tm;
-    using WType = typename Wei<Core_T, Core_T::ISA>::StorageWeight;
+    using WType = typename Wei<Core_T>::StorageWeight;
     WType tmpB(0);
-    if constexpr (std::is_same_v<Wei<Core_T, Core_T::ISA>,
-                                 prologue_b::gemm::WeightKBlockNInteger<Core_T, Core_T::ISA>>) {
-      tmpB = kernel.mProB.createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>, bestla_dtype<float>, false);
+    if constexpr (std::is_same_v<Wei<Core_T>, prologue_b::gemm::WeightKBlockNInteger<Core_T>>) {
+      tmpB =
+          Launcher::PrologueB::createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>, bestla_dtype<float>, false);
 
-    } else if constexpr (std::is_same_v<Wei<Core_T, Core_T::ISA>,
-                                        prologue_b::gemm::WeightKBlockNFloat<Core_T, Core_T::ISA>>) {
-      tmpB = kernel.mProB.createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>);
+    } else if constexpr (std::is_same_v<Wei<Core_T>, prologue_b::gemm::WeightKBlockNFloat<Core_T>>) {
+      tmpB = Launcher::PrologueB::createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>);
     }
     std::vector<WType> packBs(batch, 0);
     avector<int8_t> bufB(tmpB.mSize * batch);
@@ -622,7 +614,7 @@ class UTWOQ_CompBf16 {
       packBs[i] = tmpB;
       packBs[i].assign(bufB.data() + i * tmpB.mSize);
     }
-    kernel.mProB.packWeight(n, k, B, n, &packBs[0], UT_Threading::get());
+    Launcher::PrologueB::packWeight(n, k, B, n, &packBs[0], UT_Threading::get());
     for (size_t i = 1; i < batch; i++) {
       memcpy(packBs[i].template WPtr<void>(), packBs[0].template WPtr<void>(), packBs[0].template WSize<char>());
       memcpy(packBs[i].template SPtr<void>(), packBs[0].template SPtr<void>(), packBs[0].CSize() * sizeof(Scale_T));
@@ -637,7 +629,7 @@ class UTWOQ_CompBf16 {
         log.start();
         GemmProblem gp(1, m, n, k);
         typename Launcher::Param args{gp, {A + i * m * k, k}, {&packBs[i]}, {C + i * m * n, n}};
-        parallel::GemmRun<Parallel>(kernel, args, UT_Threading::get());
+        parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
         log.stop();
         if (tm.stop() >= timems) {
           break;
@@ -652,7 +644,7 @@ class UTWOQ_CompBf16 {
            corestr, log.get_log_str(), flops, flops / cores, band);
   }
 
-  template <template <class _T, BTLA_ISA> class Wei, typename Scale_T>
+  template <template <class _T> class Wei, typename Scale_T>
   void benchmark_all(int m, int n, int k, BTLA_DTYPE qtype) {
     auto memsize = gemm_memsize(m, n, k, BTLA_DTYPE::F32, qtype, BTLA_DTYPE::F32);
     int batch = auto_batch(memsize);
@@ -715,31 +707,32 @@ class UTWOQ_CompInt8 {
 
   using PcWriteBack = epilogue::gemm::PcKBlockCompInt8Epilogue<epilogue::gemm::AccumulatorWriteBackFp32>;
 
-  template <typename Core_T, typename LOG_T, template <class _T, BTLA_ISA> class Wei, typename Scale_T>
+  template <typename Core_T, typename LOG_T, template <class _T> class Wei, typename Scale_T>
   void benchmark_pc(int m, int n, int k, int batch, int blocksize, float* A, float* B, float* C, float timems,
                     int threads, BTLA_DTYPE qtype, bool isasym) {
     LOG_T log;
     using Parallel = parallel::gemm::SchedulerBase<Core_T>;
-    using Launcher = wrapper::gemm::LauncherBase<Core_T::ISA, Core_T, prologue_a::gemm::ActivationF32KBlockQuantize,
-                                                 Wei, PcWriteBack>;
-    Launcher kernel;
+    using Launcher =
+        wrapper::gemm::LauncherBase<Core_T, prologue_a::gemm::ActivationF32KBlockQuantize, Wei, PcWriteBack>;
+
     UT_Threading::set_threads(threads);
     auto corestr = gemm::CoreAttr::to_str(Core_T::ID);
     utils::timer<std::chrono::milliseconds> tm;
-    using WType = typename Wei<Core_T, Core_T::ISA>::StorageWeight;
-    WType tmpB = kernel.mProB.createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>, bestla_dtype<float>, isasym);
+    using WType = typename Wei<Core_T>::StorageWeight;
+    WType tmpB =
+        Launcher::PrologueB::createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>, bestla_dtype<float>, isasym);
     std::vector<WType> packBs(batch, 0);
     avector<int8_t> bufB(tmpB.mSize * batch);
     for (size_t i = 0; i < batch; i++) {
       packBs[i] = tmpB;
       packBs[i].assign(bufB.data() + i * tmpB.mSize);
     }
-    kernel.mProB.packWeight(n, k, B, n, &packBs[0], UT_Threading::get());
+    Launcher::PrologueB::packWeight(n, k, B, n, &packBs[0], UT_Threading::get());
     for (size_t i = 1; i < batch; i++) {
       memcpy(packBs[i].template WPtr<void>(), packBs[0].template WPtr<void>(), packBs[0].template WSize<char>());
       memcpy(packBs[i].template SPtr<void>(), packBs[0].template SPtr<void>(), packBs[0].CSize() * sizeof(Scale_T));
     }
-    auto quanA = kernel.mProA.createStorage(m, k, blocksize, false);
+    auto quanA = Launcher::PrologueA::createStorage(m, k, blocksize, false);
     utils::avector<int8_t> bufferA(quanA.mSize);
     quanA.assign(bufferA.data());
     auto psize = (size_t)m * n * k * 2;
@@ -761,7 +754,7 @@ class UTWOQ_CompInt8 {
             {{packBs[i].template SPtr<char>(), packBs[i].SDtype(), quanA.template SPtr<float>(),
               quanA.template ZPtr<uint8_t>(), packBs[i].template RPtr<char>(), packBs[i].RDtype(), nullptr, nullptr, k},
              {C + i * m * n, n}}};
-        parallel::GemmRunWithA<Parallel>(kernel, args, UT_Threading::get());
+        parallel::GemmRunWithA<Parallel, Launcher>(args, UT_Threading::get());
         log.stop();
         if (tm.stop() >= timems) {
           break;
@@ -776,32 +769,32 @@ class UTWOQ_CompInt8 {
            corestr, log.get_log_str(), flops, flops / cores, band);
   }
 
-  template <typename Core_T, typename LOG_T, template <class _T, BTLA_ISA> class Wei, typename Scale_T>
+  template <typename Core_T, typename LOG_T, template <class _T> class Wei, typename Scale_T>
   void benchmark(int m, int n, int k, int batch, int blocksize, float* A, float* B, float* C, float timems, int threads,
                  BTLA_DTYPE qtype, bool isasym) {
     LOG_T log;
     using Parallel = parallel::gemm::SchedulerKBlockS<Core_T>;
-    using Launcher =
-        wrapper::gemm::LauncherIntKBlock<Core_T::ISA, Core_T, prologue_a::gemm::ActivationF32KBlockQuantize, Wei,
-                                         epilogue::gemm::AccumulatorWriteBackFp32>;
-    Launcher kernel;
+    using Launcher = wrapper::gemm::LauncherIntKBlock<Core_T, prologue_a::gemm::ActivationF32KBlockQuantize, Wei,
+                                                      epilogue::gemm::AccumulatorWriteBackFp32>;
+
     UT_Threading::set_threads(threads);
     auto corestr = gemm::CoreAttr::to_str(Core_T::ID);
     utils::timer<std::chrono::milliseconds> tm;
-    using WType = typename Wei<Core_T, Core_T::ISA>::StorageWeight;
-    WType tmpB = kernel.mProB.createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>, bestla_dtype<float>, isasym);
+    using WType = typename Wei<Core_T>::StorageWeight;
+    WType tmpB =
+        Launcher::PrologueB::createStorage(n, k, blocksize, qtype, bestla_dtype<Scale_T>, bestla_dtype<float>, isasym);
     std::vector<WType> packBs(batch, 0);
     avector<int8_t> bufB(tmpB.mSize * batch);
     for (size_t i = 0; i < batch; i++) {
       packBs[i] = tmpB;
       packBs[i].assign(bufB.data() + i * tmpB.mSize);
     }
-    kernel.mProB.packWeight(n, k, B, n, &packBs[0], UT_Threading::get());
+    Launcher::PrologueB::packWeight(n, k, B, n, &packBs[0], UT_Threading::get());
     for (size_t i = 1; i < batch; i++) {
       memcpy(packBs[i].template WPtr<void>(), packBs[0].template WPtr<void>(), packBs[0].template WSize<char>());
       memcpy(packBs[i].template SPtr<void>(), packBs[0].template SPtr<void>(), packBs[0].CSize() * sizeof(Scale_T));
     }
-    auto quanA = kernel.mProA.createStorage(m, k, blocksize, false);
+    auto quanA = Launcher::PrologueA::createStorage(m, k, blocksize, false);
     utils::avector<int8_t> bufferA(quanA.mSize);
     quanA.assign(bufferA.data());
     auto psize = (size_t)m * n * k * 2;
@@ -817,7 +810,7 @@ class UTWOQ_CompInt8 {
         log.start();
         GemmProblem gp(1, m, n, k, blocksize);
         typename Launcher::Param args{gp, {A + i * m * k, k, &quanA}, {&packBs[i]}, {C + i * m * n, n}};
-        parallel::GemmRunWithA<Parallel>(kernel, args, UT_Threading::get());
+        parallel::GemmRunWithA<Parallel, Launcher>(args, UT_Threading::get());
         log.stop();
         if (tm.stop() >= timems) {
           break;
@@ -831,7 +824,7 @@ class UTWOQ_CompInt8 {
            corestr, log.get_log_str(), flops, flops / threads, band);
   }
 
-  template <template <class _T, BTLA_ISA> class Wei, typename Scale_T>
+  template <template <class _T> class Wei, typename Scale_T>
   void benchmark_all(int m, int n, int k, BTLA_DTYPE qtype, bool isasym = false) {
     auto memsize = gemm_memsize(m, n, k, BTLA_DTYPE::F32, qtype, BTLA_DTYPE::F32);
     int batch = auto_batch(memsize);

--- a/bestla/bestla/ut/bestla_parallel.cpp
+++ b/bestla/bestla/ut/bestla_parallel.cpp
@@ -144,11 +144,11 @@ class UT_SchedulerGemmKBlockNew {
     ut<gemm::ICoreRowNAmxint8SS<64, 16>>(1, 4096, 4096, 64, 24, 32 * 1024);
     ut<gemm::ICoreRowNAmxint8SS<64, 16>>(2048, 4096, 4096, 64, 24);
     ut<gemm::ICoreRowNAmxint8SS<64, 16>>(2048, 4096, 4096, 4096, 56);
-    ut<gemm::ICoreRowNAmxint8SS<64, 16>>(2048, 4096, 4096, 32, 56);
+    ut<gemm::ICoreRowNAmxint8SS<64, 16>>(2048, 4096, 4096, 64, 56);
     ut<gemm::ICoreRowNAmxint8SS<64, 16>>(4, 4096, 4096, 128, 48);
-    ut<gemm::ICoreRowNAmxint8SS<64, 16>>(4, 4096, 3072, 32, 48);
+    ut<gemm::ICoreRowNAmxint8SS<64, 16>>(4, 4096, 3072, 64, 48);
     ut<gemm::ICoreRowNAmxint8SS<64, 16>>(2048, 4096, 3072, 3072, 48);
-    ut<gemm::ICoreRowNAmxint8SS<64, 16>>(2048, 4096, 3072, 32, 56);
+    ut<gemm::ICoreRowNAmxint8SS<64, 16>>(2048, 4096, 3072, 64, 56);
   }
 
   template <class GemmCore_T>

--- a/bestla/bestla/ut/bestla_prologue_a.cpp
+++ b/bestla/bestla/ut/bestla_prologue_a.cpp
@@ -25,15 +25,16 @@ class UT_ActivationBase {
     for (int i = 0; i < src.size(); i++) {
       src[i] = static_cast<BType>(i);
     }
-    prologue_a::gemm::ActivationBase<_T, BTLA_ISA::NoSIMD> reorderref;
-    prologue_a::gemm::ActivationBase<_T, BTLA_ISA::AVX512F> reorderavx512;
+    using ProA = prologue_a::gemm::ActivationBase<_T>;
     auto dstrefptr = dstref.data();
     auto dstptr = dst.data();
     int dststride = 0;
-    reorderref.getActivation(&dstrefptr, &dststride, {src.data(), lda}, m, k, 0, 0, cache, CacheSize);
+    ProA::template getActivation<BTLA_ISA::NoSIMD>(&dstrefptr, &dststride, {src.data(), lda}, m, k, 0, 0, cache,
+                                                   CacheSize);
     GetCPUDevice();
     if (_cd->AVX512F()) {
-      reorderavx512.getActivation(&dstptr, &dststride, {src.data(), lda}, m, k, 0, 0, cache, CacheSize);
+      ProA::template getActivation<BTLA_ISA::AVX512F>(&dstptr, &dststride, {src.data(), lda}, m, k, 0, 0, cache,
+                                                      CacheSize);
       ut::buffer_error(dst.data(), dstref.data(), dst.size());
     }
   }
@@ -64,14 +65,15 @@ class UT_ActivationConverter {
     for (int i = 0; i < src.size(); i++) {
       src[i] = static_cast<SrcType>(float(i));
     }
-    prologue_a::gemm::ActivationConverter<_T, BTLA_ISA::NoSIMD, SRC_T> reorderref;
-    prologue_a::gemm::ActivationConverter<_T, BTLA_ISA::AVX512F, SRC_T> reorderavx512;
+    using ProA = prologue_a::gemm::ActivationConverter<_T, SRC_T>;
     auto dstptr = dstref.data();
     int dststride = 0;
-    auto ret = reorderref.getActivation(&dstptr, &dststride, {src.data(), lda}, m, k, 0, 0, cache, CacheSize);
+    auto ret = ProA::template getActivation<BTLA_ISA::NoSIMD>(&dstptr, &dststride, {src.data(), lda}, m, k, 0, 0, cache,
+                                                              CacheSize);
     assert(ret == BTLA_CODE::Success);
     dstptr = dst.data();
-    ret = reorderavx512.getActivation(&dstptr, &dststride, {src.data(), lda}, m, k, 0, 0, cache, CacheSize);
+    ret = ProA::template getActivation<BTLA_ISA::AVX512F>(&dstptr, &dststride, {src.data(), lda}, m, k, 0, 0, cache,
+                                                          CacheSize);
     assert(ret == BTLA_CODE::Success);
     ut::buffer_error(dst.data(), dstref.data(), dst.size(), AType{0});
     aligned_vector<SrcType> revert(dst.size());
@@ -127,11 +129,12 @@ class UT_ActivationU8KBlockQuantize {
 
     kernel::ref::quantize_fp_u8_colblock(m, k, raw.data(), lda, q.data(), lda, scales.data(), kcount, zp.data(), kblock,
                                          hasreduce ? reduce.data() : nullptr);
-    prologue_a::gemm::ActivationF32KBlockQuantize<_T, _T::ISA> actA;
-    auto quanAct = actA.createStorage(m, k, kblock, hasreduce);
+    using ProA = prologue_a::gemm::ActivationF32KBlockQuantize<_T>;
+    auto constexpr ISA = _T::ISA;
+    auto quanAct = ProA::createStorage(m, k, kblock, hasreduce);
     avector<int8_t> bufA(quanAct.mSize);
     quanAct.assign(bufA.data());
-    actA.quantize({raw.data(), lda, &quanAct}, m, k, UT_Threading::get());
+    ProA::template quantize<ISA>({raw.data(), lda, &quanAct}, m, k, UT_Threading::get());
 
     ut::buffer_error(q.data(), quanAct.template APtr<uint8_t>(), q.size(), uint8_t(1));
     ut::buffer_error(zp.data(), quanAct.template ZPtr<uint8_t>(), zp.size(), uint8_t(1));
@@ -182,11 +185,12 @@ class UT_ActivationS8KBlockQuantize {
     q.resize(m * lda);
     kernel::ref::quantize_fp_s8_colblock(m, k, raw.data(), k, q.data(), lda, scales.data(), kcount, kblock,
                                          hasreduce ? reduce.data() : nullptr);
-    prologue_a::gemm::ActivationF32KBlockQuantize<_T, BTLA_ISA::AVX512F> actA;
-    auto quanAct = actA.createStorage(m, k, kblock, hasreduce);
+    using ProA = prologue_a::gemm::ActivationF32KBlockQuantize<_T>;
+    auto quanAct = ProA::createStorage(m, k, kblock, hasreduce);
+    auto constexpr ISA = BTLA_ISA::AVX512F;
     avector<int8_t> bufA(quanAct.mSize);
     quanAct.assign(bufA.data());
-    actA.quantize({raw.data(), k, &quanAct}, m, k, UT_Threading::get());
+    ProA::template quantize<ISA>({raw.data(), k, &quanAct}, m, k, UT_Threading::get());
     ut::buffer_error(q.data(), quanAct.template APtr<int8_t>(), q.size(), int8_t(1));
     if (hasreduce) {
       avector<float> redref(reduce.size(), 0.f), redqref(reduce.size(), 0.f);
@@ -210,8 +214,10 @@ class UT_ShuffleActivationKblock {
  public:
   UT_ShuffleActivationKblock() {
     UT_START();
+    CheckISA(AVX2);
     ut<float, gemm::SCoreRowNAvx2<48, 2>>(15, 63);
     ut<bf16, gemm::SCoreRowNAvx2<48, 2>>(15, 63);
+    CheckISA(AMX_BF16);
     ut<float, gemm::HCoreRowNAmxbf16<64, 16>>(15, 63);
     ut<bf16, gemm::HCoreRowNAmxbf16<64, 16>>(15, 63);
     dynamic_ut(15, 63, 2, true);
@@ -228,17 +234,18 @@ class UT_ShuffleActivationKblock {
       indices[i] = i % 2 == 0 ? (i + 1) == indices.size() ? i : i + 1 : i - 1;
     }
     for (int i = 0; i < src.size(); i++) src[i] = static_cast<_SRC_T>(i);
-    prologue_a::gemm::ShuffleActivationKBlockBase<GC, BTLA_ISA::NoSIMD, _SRC_T> kernel;
+    using ProA = prologue_a::gemm::ShuffleActivationKBlockBase<GC, _SRC_T>;
     auto dstrefptr = dstref.data();
     auto dstptr = dst.data();
     int dststride = 0;
-    auto reordA = kernel.createReorderStorage(m, k, 32);
+    auto reordA = ProA::createReorderStorage(m, k, 32);
     avector<int8_t> bufA(reordA.mSize);
     reordA.assign(bufA.data());
-    kernel.preprocess({src.data(), k, nullptr, indices.data(), &reordA}, m, k, 32, UT_Threading::get());
+    ProA::template preprocess<GC::ISA>({src.data(), k, nullptr, indices.data(), &reordA}, m, k, 32,
+                                       UT_Threading::get());
 
-    kernel.getActivation(&dstptr, &dststride, {src.data(), k, nullptr, indices.data(), &reordA}, m, kpad, 0, 0, cache,
-                         CacheSize);
+    ProA::template getActivation<GC::ISA>(&dstptr, &dststride, {src.data(), k, nullptr, indices.data(), &reordA}, m,
+                                          kpad, 0, 0, cache, CacheSize);
     for (int i = 0; i < m; i++) {
       int j = 0;
       for (; j < k; j++) dstrefptr[i * kpad + j] = static_cast<BType>(src[i * k + indices[j]]);
@@ -266,13 +273,14 @@ class UT_ShuffleActivationKblock {
     kernel::ref::shuffle_activation(raw_cp.data(), raw.data(), m, k, 0, 0, indices.data(), k, k);
     kernel::ref::quantize_fp_s8_colblock(m, k, raw.data(), k, q.data(), lda, scales.data(), kcount, kblock,
                                          hasreduce ? reduce.data() : nullptr);
-    prologue_a::gemm::ShuffleActivationKBlockQuantize<GC, BTLA_ISA::NoSIMD, float> actA;
-    auto quanAct = actA.createQuantStorage(m, k, kblock, hasreduce);
-    auto reordAct = actA.createReorderStorage(m, k, kblock);
+    using ProA = prologue_a::gemm::ShuffleActivationKBlockQuantize<GC, float>;
+    auto constexpr RunISA = BTLA_ISA::NoSIMD;
+    auto quanAct = ProA::createQuantStorage(m, k, kblock, hasreduce);
+    auto reordAct = ProA::createReorderStorage(m, k, kblock);
     avector<int8_t> bufA(quanAct.mSize + reordAct.mSize);
     quanAct.assign(bufA.data());
     reordAct.assign(bufA.data() + quanAct.mSize);
-    actA.quantize({raw_cp.data(), k, &quanAct, indices.data(), &reordAct}, m, k, UT_Threading::get());
+    ProA::template quantize<RunISA>({raw_cp.data(), k, &quanAct, indices.data(), &reordAct}, m, k, UT_Threading::get());
     ut::buffer_error(quanAct.template APtr<int8_t>(), q.data(), q.size(), int8_t(1));
     if (hasreduce) {
       avector<float> redref(reduce.size(), 0.f), redqref(reduce.size(), 0.f);

--- a/bestla/bestla/ut/bestla_prologue_a.cpp
+++ b/bestla/bestla/ut/bestla_prologue_a.cpp
@@ -2,7 +2,6 @@
 #include "bestla_ut.h"
 #include "kernel_avx512f.h"
 
-#ifdef BTLA_UT_PROLOGUE_A
 namespace bestla {
 using namespace utils;
 namespace ut {
@@ -134,7 +133,7 @@ class UT_ActivationU8KBlockQuantize {
     auto quanAct = ProA::createStorage(m, k, kblock, hasreduce);
     avector<int8_t> bufA(quanAct.mSize);
     quanAct.assign(bufA.data());
-    ProA::template quantize({raw.data(), lda, &quanAct}, m, k, UT_Threading::get());
+    ProA::quantize({raw.data(), lda, &quanAct}, m, k, UT_Threading::get());
 
     ut::buffer_error(q.data(), quanAct.template APtr<uint8_t>(), q.size(), uint8_t(1));
     ut::buffer_error(zp.data(), quanAct.template ZPtr<uint8_t>(), zp.size(), uint8_t(1));
@@ -190,7 +189,7 @@ class UT_ActivationS8KBlockQuantize {
     auto constexpr ISA = BTLA_ISA::AVX512F;
     avector<int8_t> bufA(quanAct.mSize);
     quanAct.assign(bufA.data());
-    ProA::template quantize({raw.data(), k, &quanAct}, m, k, UT_Threading::get());
+    ProA::quantize({raw.data(), k, &quanAct}, m, k, UT_Threading::get());
     ut::buffer_error(q.data(), quanAct.template APtr<int8_t>(), q.size(), int8_t(1));
     if (hasreduce) {
       avector<float> redref(reduce.size(), 0.f), redqref(reduce.size(), 0.f);
@@ -241,8 +240,7 @@ class UT_ShuffleActivationKblock {
     auto reordA = ProA::createReorderStorage(m, k, 32);
     avector<int8_t> bufA(reordA.mSize);
     reordA.assign(bufA.data());
-    ProA::template preprocess({src.data(), k, nullptr, indices.data(), &reordA}, m, k, 32,
-                                       UT_Threading::get());
+    ProA::preprocess({src.data(), k, nullptr, indices.data(), &reordA}, m, k, 32, UT_Threading::get());
 
     ProA::template getActivation<GC::ISA>(&dstptr, &dststride, {src.data(), k, nullptr, indices.data(), &reordA}, m,
                                           kpad, 0, 0, cache, CacheSize);
@@ -301,4 +299,3 @@ static UT_ShuffleActivationKblock sUT_ShuffleActivationKblock;
 #endif
 }  // namespace ut
 }  // namespace bestla
-#endif

--- a/bestla/bestla/ut/bestla_prologue_a.cpp
+++ b/bestla/bestla/ut/bestla_prologue_a.cpp
@@ -134,7 +134,7 @@ class UT_ActivationU8KBlockQuantize {
     auto quanAct = ProA::createStorage(m, k, kblock, hasreduce);
     avector<int8_t> bufA(quanAct.mSize);
     quanAct.assign(bufA.data());
-    ProA::template quantize<ISA>({raw.data(), lda, &quanAct}, m, k, UT_Threading::get());
+    ProA::template quantize({raw.data(), lda, &quanAct}, m, k, UT_Threading::get());
 
     ut::buffer_error(q.data(), quanAct.template APtr<uint8_t>(), q.size(), uint8_t(1));
     ut::buffer_error(zp.data(), quanAct.template ZPtr<uint8_t>(), zp.size(), uint8_t(1));
@@ -190,7 +190,7 @@ class UT_ActivationS8KBlockQuantize {
     auto constexpr ISA = BTLA_ISA::AVX512F;
     avector<int8_t> bufA(quanAct.mSize);
     quanAct.assign(bufA.data());
-    ProA::template quantize<ISA>({raw.data(), k, &quanAct}, m, k, UT_Threading::get());
+    ProA::template quantize({raw.data(), k, &quanAct}, m, k, UT_Threading::get());
     ut::buffer_error(q.data(), quanAct.template APtr<int8_t>(), q.size(), int8_t(1));
     if (hasreduce) {
       avector<float> redref(reduce.size(), 0.f), redqref(reduce.size(), 0.f);
@@ -241,7 +241,7 @@ class UT_ShuffleActivationKblock {
     auto reordA = ProA::createReorderStorage(m, k, 32);
     avector<int8_t> bufA(reordA.mSize);
     reordA.assign(bufA.data());
-    ProA::template preprocess<GC::ISA>({src.data(), k, nullptr, indices.data(), &reordA}, m, k, 32,
+    ProA::template preprocess({src.data(), k, nullptr, indices.data(), &reordA}, m, k, 32,
                                        UT_Threading::get());
 
     ProA::template getActivation<GC::ISA>(&dstptr, &dststride, {src.data(), k, nullptr, indices.data(), &reordA}, m,
@@ -280,7 +280,7 @@ class UT_ShuffleActivationKblock {
     avector<int8_t> bufA(quanAct.mSize + reordAct.mSize);
     quanAct.assign(bufA.data());
     reordAct.assign(bufA.data() + quanAct.mSize);
-    ProA::template quantize<RunISA>({raw_cp.data(), k, &quanAct, indices.data(), &reordAct}, m, k, UT_Threading::get());
+    ProA::quantize({raw_cp.data(), k, &quanAct, indices.data(), &reordAct}, m, k, UT_Threading::get());
     ut::buffer_error(quanAct.template APtr<int8_t>(), q.data(), q.size(), int8_t(1));
     if (hasreduce) {
       avector<float> redref(reduce.size(), 0.f), redqref(reduce.size(), 0.f);

--- a/bestla/bestla/ut/bestla_prologue_b.cpp
+++ b/bestla/bestla/ut/bestla_prologue_b.cpp
@@ -467,7 +467,7 @@ class UT_CompFp32 {
            bestla_dtype_str(qtype), gemm::CoreAttr::to_str(GemmCore_T::ID), bestla_dtype_str(stype), isAsym);
     auto constexpr ISA = GemmCore_T::ISA;
     using Launcher =
-        wrapper::gemm::LauncherBase<ISA, GemmCore_T, prologue_a::gemm::ActivationKBlockBaseF32,
+        wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationKBlockBaseF32,
                                     prologue_b::gemm::WeightKBlockNInteger, epilogue::gemm::AccumulatorWriteBackFp32>;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
     Launcher launcher;
@@ -510,7 +510,7 @@ class UT_CompFp32 {
     printf("Test Case %s: %d %d %d-%d type:%s core:%s scaletype:%s\n", __FUNCTION__, m, n, k, blocksize,
            bestla_dtype_str(qtype), gemm::CoreAttr::to_str(GemmCore_T::ID), bestla_dtype_str(stype));
     auto constexpr ISA = GemmCore_T::ISA;
-    using Launcher = wrapper::gemm::LauncherBase<ISA, GemmCore_T, prologue_a::gemm::ActivationBase, Wei,
+    using Launcher = wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase, Wei,
                                                  epilogue::gemm::AccumulatorWriteBackFp32>;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
     Launcher launcher;
@@ -657,7 +657,7 @@ class UT_CompInt8 {
     printf("Test Case %s: %d %d %d-%d type:%s core:%s scaletype:%s Asym:%d\n", __FUNCTION__, m, n, k, blocksize,
            bestla_dtype_str(qtype), gemm::CoreAttr::to_str(GemmCore_T::ID), bestla_dtype_str(stype), isAsym);
     auto constexpr ISA = GemmCore_T::ISA;
-    using Launcher = wrapper::gemm::LauncherIntKBlock<ISA, GemmCore_T, prologue_a::gemm::ActivationF32KBlockQuantize,
+    using Launcher = wrapper::gemm::LauncherIntKBlock<GemmCore_T, prologue_a::gemm::ActivationF32KBlockQuantize,
                                                       prologue_b::gemm::WeightKBlockNInteger,
                                                       epilogue::gemm::AccumulatorWriteBackFp32>;
     using Parallel = parallel::gemm::SchedulerKBlockS<GemmCore_T>;
@@ -711,9 +711,8 @@ class UT_CompInt8 {
            bestla_dtype_str(qtype), gemm::CoreAttr::to_str(GemmCore_T::ID), bestla_dtype_str(stype), isAsym);
     auto constexpr ISA = GemmCore_T::ISA;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
-    using Launcher =
-        wrapper::gemm::LauncherBase<GemmCore_T::ISA, GemmCore_T, prologue_a::gemm::ActivationF32KBlockQuantize,
-                                    prologue_b::gemm::WeightKBlockNInteger, PcWriteBack>;
+    using Launcher = wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationF32KBlockQuantize,
+                                                 prologue_b::gemm::WeightKBlockNInteger, PcWriteBack>;
     Launcher launcher;
     blocksize = blocksize == -1 ? k : blocksize;
     int kblks = updiv(k, blocksize);
@@ -819,7 +818,7 @@ class UT_CompBf16 {
     printf("Test Case %s: %d %d %d-%d type:%s core:%s scaletype:%s\n", __FUNCTION__, m, n, k, blocksize,
            bestla_dtype_str(qtype), gemm::CoreAttr::to_str(GemmCore_T::ID), type_str<Scale_T>);
     auto constexpr ISA = GemmCore_T::ISA;
-    using Launcher = wrapper::gemm::LauncherBase<ISA, GemmCore_T, prologue_a::gemm::ActivationBase, Wei,
+    using Launcher = wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase, Wei,
                                                  epilogue::gemm::AccumulatorWriteBackFp32>;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
 
@@ -892,7 +891,7 @@ class UT_ORT_NBits {
            bestla_dtype_str(qtype), gemm::CoreAttr::to_str(GemmCore_T::ID), isasym);
     auto constexpr ISA = GemmCore_T::ISA;
     using Launcher =
-        wrapper::gemm::LauncherBase<ISA, GemmCore_T, prologue_a::gemm::ActivationKBlockBaseF32,
+        wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationKBlockBaseF32,
                                     prologue_b::gemm::WeightKBlockNInteger, epilogue::gemm::AccumulatorWriteBackFp32>;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
     Launcher launcher;
@@ -976,7 +975,7 @@ class UT_ORT_NBits {
            bestla_dtype_str(qtype), gemm::CoreAttr::to_str(GemmCore_T::ID), isasym);
     auto constexpr ISA = GemmCore_T::ISA;
     using Launcher =
-        wrapper::gemm::LauncherBase<ISA, GemmCore_T, prologue_a::gemm::ActivationKBlockBaseF32,
+        wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationKBlockBaseF32,
                                     prologue_b::gemm::WeightKBlockNInteger, epilogue::gemm::AccumulatorWriteBackFp32>;
     using Parallel = parallel::gemm::SchedulerKBlockS<GemmCore_T>;
     Launcher launcher;
@@ -1086,7 +1085,7 @@ class UT_CompFp16 {
     printf("Test Case %s: %d %d %d-%d type:%s core:%s scaletype:%s\n", __FUNCTION__, m, n, k, blocksize,
            bestla_dtype_str(qtype),gemm::CoreAttr::to_str(GemmCore_T::ID), type_str<Scale_T>);
     auto constexpr ISA = GemmCore_T::ISA;
-    using Launcher = wrapper::gemm::LauncherKBlock<ISA, GemmCore_T, prologue_a::gemm::ActivationBase, Wei,
+    using Launcher = wrapper::gemm::LauncherKBlock<GemmCore_T, prologue_a::gemm::ActivationBase, Wei,
                                                           epilogue::gemm::CompFp32BlockEpilogue,
                                                           epilogue::gemm::AccumulatorWriteBackFp32>;
     using Parallel = parallel::gemm::SchedulerKBlock<GemmCore_T>;

--- a/bestla/bestla/ut/bestla_prologue_b.cpp
+++ b/bestla/bestla/ut/bestla_prologue_b.cpp
@@ -671,7 +671,7 @@ class UT_CompFp32 {
     launcher.mProB.unpackWeight(n, k, &packedw, matBf32.data(), n, UT_Threading::get());
     gemmref_fp32fp32fp32(m, n, k, matAf32.data(), matBf32.data(), refCupk.data(), k, n, n);
 
-    Launcher::PrologueA::reduce<ISA>({matAf32.data(), k, &reduceA}, m, k, blocksize, UT_Threading::get());
+    Launcher::PrologueA::reduce({matAf32.data(), k, &reduceA}, m, k, blocksize, UT_Threading::get());
     utils::GemmProblem gp(1, m, n, k, blocksize);
     typename Launcher::Param args{gp, {matAf32.data(), k, &reduceA}, {&packedw}, {matC.data(), n}};
     parallel::GemmRun<Parallel>(launcher, args, UT_Threading::get());
@@ -1106,7 +1106,7 @@ class UT_ORT_NBits {
         }
       }
       rA.assign(tmpA.data());
-      Launcher::PrologueA::template reduce<ISA>({matAf32.data(), k, &rA}, m, k, blocksize,
+      Launcher::PrologueA::template reduce({matAf32.data(), k, &rA}, m, k, blocksize,
                                                 UT_Threading::get());  // for reduce UT
       buffer_error(reduceA.data(), rA.template RPtr<float>(), reduceA.size(), FP32_ERR);
       memset(tmpA.data(), 0, tmpA.size());  // clear

--- a/bestla/bestla/ut/bestla_prologue_b.cpp
+++ b/bestla/bestla/ut/bestla_prologue_b.cpp
@@ -928,8 +928,8 @@ class UT_ORT_NBits {
         }
       }
       rA.assign(tmpA.data());
-      Launcher::PrologueA::template reduce({matAf32.data(), k, &rA}, m, k, blocksize,
-                                           UT_Threading::get());  // for reduce UT
+      Launcher::PrologueA::reduce({matAf32.data(), k, &rA}, m, k, blocksize,
+                                  UT_Threading::get());  // for reduce UT
       buffer_error(reduceA.data(), rA.template RPtr<float>(), reduceA.size(), FP32_ERR);
       memset(tmpA.data(), 0, tmpA.size());  // clear
     }

--- a/bestla/bestla/ut/bestla_ut.h
+++ b/bestla/bestla/ut/bestla_ut.h
@@ -70,7 +70,7 @@ static inline int auto_batch(size_t memsize) {
   auto L3 = _cd->getL3CacheSize();
   size_t constexpr Enlarge = 4;
   size_t constexpr TargetMem = 1LL << 30;
-  auto batch = std::max(L3 * Enlarge, TargetMem) / memsize;
+  auto batch = static_cast<int>(std::max(L3 * Enlarge, TargetMem) / memsize);
   return batch > 1 ? batch : 2;
 }
 

--- a/bestla/bestla/ut/bestla_wrapper.cpp
+++ b/bestla/bestla/ut/bestla_wrapper.cpp
@@ -35,7 +35,7 @@ class UT_Fp32Fp32 {
     using Launcher =
         wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
                                     epilogue::gemm::AccumulatorWriteBackFp32>;
-    Launcher launcher;
+
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
 
     auto packw = Launcher::PrologueB::createStorage(n, k);
@@ -44,7 +44,7 @@ class UT_Fp32Fp32 {
     Launcher::PrologueB::packWeight(n, k, {matB.data(), n, &packw}, UT_Threading::get());
     utils::GemmProblem gp(1, m, n, k);
     typename Launcher::Param args{gp, {matA.data(), k}, {matB.data(), n, &packw}, {matC.data(), n}};
-    parallel::GemmRun<Parallel>(launcher, args, UT_Threading::get());
+    parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
     ut::buffer_error(ref.data(), matC.data(), ref.size(), 0.001f);
   }
 };
@@ -121,7 +121,7 @@ class UT_U8S8S32 {
     gemmref_fp32fp32fp32(m, n, k, matAf32.data(), matBf32.data(), refC.data(), k, n, n);
     using Launcher = wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase,
                                                  prologue_b::gemm::WeightPack, epilogue::gemm::ZpDequantInt32ToFp32>;
-    Launcher launcher;
+
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
 
     auto packw = Launcher::PrologueB::createStorage(n, k);
@@ -134,7 +134,7 @@ class UT_U8S8S32 {
         {matAu8.data(), k},
         {matBs8.data(), n, &packw},
         {matC.data(), n, 1, scaleAf32.data(), scaleBf32.data(), zpAu8.data(), reduceB.data()}};
-    parallel::GemmRun<Parallel>(launcher, args, UT_Threading::get());
+    parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
     ut::buffer_error(refC.data(), matC.data(), refC.size(), 0.001f);
   }
 };
@@ -188,7 +188,7 @@ class UT_S8S8S32 {
     gemmref_fp32fp32fp32(m, n, k, matAf32.data(), matBf32.data(), refC.data(), k, n, n);
     using Launcher = wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase,
                                                  prologue_b::gemm::WeightPack, epilogue::gemm::DequantInt32ToFp32>;
-    Launcher launcher;
+
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
 
     auto packw = Launcher::PrologueB::createStorage(n, k);
@@ -198,7 +198,7 @@ class UT_S8S8S32 {
     utils::GemmProblem gp(1, m, n, k);
     typename Launcher::Param args{
         gp, {matAu8.data(), k}, {matBs8.data(), n, &packw}, {matC.data(), n, 1, scaleAf32.data(), scaleBf32.data()}};
-    parallel::GemmRun<Parallel>(launcher, args, UT_Threading::get());
+    parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
     ut::buffer_error(refC.data(), matC.data(), refC.size(), 0.001f);
   }
 };
@@ -225,7 +225,7 @@ class UT_Bf16Bf16Fp32 {
     using Launcher =
         wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
                                     epilogue::gemm::AccumulatorWriteBackFp32>;
-    Launcher launcher;
+
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
     auto packw = Launcher::PrologueB::createStorage(n, k);
     avector<int8_t> buffer(packw.mSize);
@@ -238,7 +238,7 @@ class UT_Bf16Bf16Fp32 {
     gemmref_bf16bf16fp32(m, n, k, matAbf16.data(), matBbf16.data(), refC.data(), k, n, n);
     utils::GemmProblem gp(1, m, n, k);
     typename Launcher::Param args{gp, {matAbf16.data(), k}, {matBbf16.data(), n, &packw}, {matC.data(), n}};
-    parallel::GemmRun<Parallel>(launcher, args, UT_Threading::get());
+    parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
     buffer_error(refC.data(), matC.data(), refC.size(), 0.05f);
   }
 };
@@ -265,7 +265,7 @@ class UT_Fp16Fp16Fp16 {
     using Launcher =
         wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
                                     epilogue::gemm::AccumulatorWriteBackFp16>;
-    Launcher launcher;
+
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
     auto packw = Launcher::PrologueB::createStorage(n, k);
     avector<int8_t> buffer(packw.mSize);
@@ -277,7 +277,7 @@ class UT_Fp16Fp16Fp16 {
     gemmref_fp16fp16fp16(m, n, k, matAbf16.data(), matBbf16.data(), refC.data(), k, n, n);
     GemmProblem gp(1, m, n, k);
     typename Launcher::Param args{gp, {matAbf16.data(), k}, {matBbf16.data(), n, &packw}, {matC.data(), n}};
-    parallel::GemmRun<Parallel>(launcher, args, UT_Threading::get());
+    parallel::GemmRun<Parallel, Launcher>(args, UT_Threading::get());
     buffer_error(refC.data(), matC.data(), refC.size(), utils::fp16(0.0002f * k));
   }
 };

--- a/bestla/bestla/ut/bestla_wrapper.cpp
+++ b/bestla/bestla/ut/bestla_wrapper.cpp
@@ -33,8 +33,8 @@ class UT_Fp32Fp32 {
     fill_buffer_randn(matB.data(), matB.size(), -0.5f, 0.5f);
     gemmref_fp32fp32fp32(m, n, k, matA.data(), matB.data(), ref.data(), k, n, n);
     using Launcher =
-        wrapper::gemm::LauncherBase<GemmCore_T::ISA, GemmCore_T, prologue_a::gemm::ActivationBase,
-                                    prologue_b::gemm::WeightPack, epilogue::gemm::AccumulatorWriteBackFp32>;
+        wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
+                                    epilogue::gemm::AccumulatorWriteBackFp32>;
     Launcher launcher;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
 
@@ -119,7 +119,7 @@ class UT_U8S8S32 {
       }
     }
     gemmref_fp32fp32fp32(m, n, k, matAf32.data(), matBf32.data(), refC.data(), k, n, n);
-    using Launcher = wrapper::gemm::LauncherBase<GemmCore_T::ISA, GemmCore_T, prologue_a::gemm::ActivationBase,
+    using Launcher = wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase,
                                                  prologue_b::gemm::WeightPack, epilogue::gemm::ZpDequantInt32ToFp32>;
     Launcher launcher;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
@@ -186,7 +186,7 @@ class UT_S8S8S32 {
       }
     }
     gemmref_fp32fp32fp32(m, n, k, matAf32.data(), matBf32.data(), refC.data(), k, n, n);
-    using Launcher = wrapper::gemm::LauncherBase<GemmCore_T::ISA, GemmCore_T, prologue_a::gemm::ActivationBase,
+    using Launcher = wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase,
                                                  prologue_b::gemm::WeightPack, epilogue::gemm::DequantInt32ToFp32>;
     Launcher launcher;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
@@ -223,8 +223,8 @@ class UT_Bf16Bf16Fp32 {
   void ut(int m, int n, int k) {
     printf("Test Case %s: %d %d %d core:%s\n", __FUNCTION__, m, n, k, gemm::CoreAttr::to_str(GemmCore_T::ID));
     using Launcher =
-        wrapper::gemm::LauncherBase<GemmCore_T::ISA, GemmCore_T, prologue_a::gemm::ActivationBase,
-                                    prologue_b::gemm::WeightPack, epilogue::gemm::AccumulatorWriteBackFp32>;
+        wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
+                                    epilogue::gemm::AccumulatorWriteBackFp32>;
     Launcher launcher;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
     auto packw = Launcher::PrologueB::createStorage(n, k);
@@ -263,8 +263,8 @@ class UT_Fp16Fp16Fp16 {
   void ut(int m, int n, int k) {
     printf("Test Case %s: %d %d %d core:%s\n", __FUNCTION__, m, n, k, gemm::CoreAttr::to_str(GemmCore_T::ID));
     using Launcher =
-        wrapper::gemm::LauncherBase<GemmCore_T::ISA, GemmCore_T, prologue_a::gemm::ActivationBase,
-                                    prologue_b::gemm::WeightPack, epilogue::gemm::AccumulatorWriteBackFp16>;
+        wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ActivationBase, prologue_b::gemm::WeightPack,
+                                    epilogue::gemm::AccumulatorWriteBackFp16>;
     Launcher launcher;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
     auto packw = Launcher::PrologueB::createStorage(n, k);

--- a/bestla/bestla/ut/bestla_wrapper.cpp
+++ b/bestla/bestla/ut/bestla_wrapper.cpp
@@ -38,10 +38,10 @@ class UT_Fp32Fp32 {
     Launcher launcher;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
 
-    auto packw = launcher.mProB.createStorage(n, k);
+    auto packw = Launcher::PrologueB::createStorage(n, k);
     avector<int8_t> buffer(packw.mSize);
     packw.assign(buffer.data());
-    launcher.mProB.packWeight(n, k, {matB.data(), n, &packw}, UT_Threading::get());
+    Launcher::PrologueB::packWeight(n, k, {matB.data(), n, &packw}, UT_Threading::get());
     utils::GemmProblem gp(1, m, n, k);
     typename Launcher::Param args{gp, {matA.data(), k}, {matB.data(), n, &packw}, {matC.data(), n}};
     parallel::GemmRun<Parallel>(launcher, args, UT_Threading::get());
@@ -124,10 +124,10 @@ class UT_U8S8S32 {
     Launcher launcher;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
 
-    auto packw = launcher.mProB.createStorage(n, k);
+    auto packw = Launcher::PrologueB::createStorage(n, k);
     avector<int8_t> buffer(packw.mSize);
     packw.assign(buffer.data());
-    launcher.mProB.packWeight(n, k, {matBs8.data(), n, &packw}, UT_Threading::get());
+    Launcher::PrologueB::packWeight(n, k, {matBs8.data(), n, &packw}, UT_Threading::get());
     utils::GemmProblem gp(1, m, n, k);
     typename Launcher::Param args{
         gp,
@@ -191,10 +191,10 @@ class UT_S8S8S32 {
     Launcher launcher;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
 
-    auto packw = launcher.mProB.createStorage(n, k);
+    auto packw = Launcher::PrologueB::createStorage(n, k);
     avector<int8_t> buffer(packw.mSize);
     packw.assign(buffer.data());
-    launcher.mProB.packWeight(n, k, {matBs8.data(), n, &packw}, UT_Threading::get());
+    Launcher::PrologueB::packWeight(n, k, {matBs8.data(), n, &packw}, UT_Threading::get());
     utils::GemmProblem gp(1, m, n, k);
     typename Launcher::Param args{
         gp, {matAu8.data(), k}, {matBs8.data(), n, &packw}, {matC.data(), n, 1, scaleAf32.data(), scaleBf32.data()}};
@@ -227,14 +227,14 @@ class UT_Bf16Bf16Fp32 {
                                     prologue_b::gemm::WeightPack, epilogue::gemm::AccumulatorWriteBackFp32>;
     Launcher launcher;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
-    auto packw = launcher.mProB.createStorage(n, k);
+    auto packw = Launcher::PrologueB::createStorage(n, k);
     avector<int8_t> buffer(packw.mSize);
     packw.assign(buffer.data());
     avector<utils::bf16> matAbf16(m * k), matBbf16(k * n);
     fill_buffer_randn(matAbf16.data(), matAbf16.size(), utils::bf16(-0.5f), utils::bf16(0.5f));
     fill_buffer_randn(matBbf16.data(), matBbf16.size(), utils::bf16(-0.5f), utils::bf16(0.5f));
     avector<float> matC(m * n), refC(m * n);
-    launcher.mProB.packWeight(n, k, {matBbf16.data(), n, &packw}, UT_Threading::get());
+    Launcher::PrologueB::packWeight(n, k, {matBbf16.data(), n, &packw}, UT_Threading::get());
     gemmref_bf16bf16fp32(m, n, k, matAbf16.data(), matBbf16.data(), refC.data(), k, n, n);
     utils::GemmProblem gp(1, m, n, k);
     typename Launcher::Param args{gp, {matAbf16.data(), k}, {matBbf16.data(), n, &packw}, {matC.data(), n}};
@@ -267,13 +267,13 @@ class UT_Fp16Fp16Fp16 {
                                     prologue_b::gemm::WeightPack, epilogue::gemm::AccumulatorWriteBackFp16>;
     Launcher launcher;
     using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
-    auto packw = launcher.mProB.createStorage(n, k);
+    auto packw = Launcher::PrologueB::createStorage(n, k);
     avector<int8_t> buffer(packw.mSize);
     packw.assign(buffer.data());
     avector<utils::fp16> matAbf16(m * k), matBbf16(k * n), matC(m * n), refC(m * n);
     fill_buffer_randn(matAbf16.data(), matAbf16.size(), utils::fp16(-0.5f), utils::fp16(0.5f));
     fill_buffer_randn(matBbf16.data(), matBbf16.size(), utils::fp16(-0.5f), utils::fp16(0.5f));
-    launcher.mProB.packWeight(n, k, {matBbf16.data(), n, &packw}, UT_Threading::get());
+    Launcher::PrologueB::packWeight(n, k, {matBbf16.data(), n, &packw}, UT_Threading::get());
     gemmref_fp16fp16fp16(m, n, k, matAbf16.data(), matBbf16.data(), refC.data(), k, n, n);
     GemmProblem gp(1, m, n, k);
     typename Launcher::Param args{gp, {matAbf16.data(), k}, {matBbf16.data(), n, &packw}, {matC.data(), n}};

--- a/bestla/bestla/ut/kernel_wrapper.cpp
+++ b/bestla/bestla/ut/kernel_wrapper.cpp
@@ -135,9 +135,9 @@ class UT_PaddingTransInterleaveMN {
     aligned_vector<T_DST> dst(col_pad * row_pad), ref(col_pad * row_pad);
     for (size_t i = 0; i < src.size(); i++) src[i] = static_cast<T_SRC>(float(i));
 
-    kernel::wrapper::PaddingTransInterleaveMN<MTile, ColPack>::template forward<BTLA_ISA::NoSIMD>(
+    kernel::wrapper::PaddingTransInterleaveMN<MTile, ColPack, T_SRC, T_DST>::template forward<BTLA_ISA::NoSIMD>(
         src.data(), ref.data(), row, col, row_pad, col_pad, row_pad, col);
-    kernel::wrapper::PaddingTransInterleaveMN<MTile, ColPack>::template forward<BTLA_ISA::AVX512_FP16>(
+    kernel::wrapper::PaddingTransInterleaveMN<MTile, ColPack, T_SRC, T_DST>::template forward<BTLA_ISA::AVX512_FP16>(
         src.data(), dst.data(), row, col, row_pad, col_pad, col, row_pad);
     ut::buffer_error(dst.data(), ref.data(), dst.size(), T_DST(100));
   }

--- a/bestla/bestla/ut/kernel_wrapper.cpp
+++ b/bestla/bestla/ut/kernel_wrapper.cpp
@@ -106,9 +106,9 @@ class UT_PaddingInterleaveMN {
     aligned_vector<T_DST> dst(row_pad * col_pad), ref(row_pad * col_pad);
     for (size_t i = 0; i < src.size(); i++) src[i] = static_cast<T_SRC>(float(i));
 
-    kernel::wrapper::PaddingInterleaveMN<NTile, RowPack>::template forward<BTLA_ISA::NoSIMD>(
+    kernel::wrapper::PaddingInterleaveMN<NTile, RowPack, T_SRC, T_DST>::template forward<BTLA_ISA::NoSIMD>(
         src.data(), ref.data(), row, col, row_pad, col_pad, row_pad, col);
-    kernel::wrapper::PaddingInterleaveMN<NTile, RowPack>::template forward<BTLA_ISA::AVX512_FP16>(
+    kernel::wrapper::PaddingInterleaveMN<NTile, RowPack, T_SRC, T_DST>::template forward<BTLA_ISA::AVX512_FP16>(
         src.data(), dst.data(), row, col, row_pad, col_pad, col, row_pad);
     ut::buffer_error(dst.data(), ref.data(), dst.size(), T_DST(100));
   }
@@ -164,9 +164,9 @@ class UT_RevertPaddingInterleaveMN {
       src[i] = static_cast<T>(i);
     }
     aligned_vector<T> reverted(row * col);
-    kernel::wrapper::PaddingInterleaveMN<NTile, PackRow>::template forward<BTLA_ISA::NoSIMD>(
+    kernel::wrapper::PaddingInterleaveMN<NTile, PackRow, T>::template forward<BTLA_ISA::NoSIMD>(
         src.data(), packed.data(), row, col, rowpad, colpad, col, rowpad);
-    kernel::wrapper::RevertPaddingInterleaveMN<NTile, PackRow>::template forward<BTLA_ISA::NoSIMD>(
+    kernel::wrapper::RevertPaddingInterleaveMN<NTile, PackRow, T>::template forward<BTLA_ISA::NoSIMD>(
         packed.data(), reverted.data(), row, col, rowpad, colpad, rowpad, col);
     ut::buffer_error(src.data(), reverted.data(), reverted.size());
   }

--- a/neural_speed/application/main_run.cpp
+++ b/neural_speed/application/main_run.cpp
@@ -353,8 +353,8 @@ int main(int argc, char** argv) {  // NOLINT
           params.repeat_last_n, params.repeat_penalty, params.presence_penalty, params.frequency_penalty, params.top_k,
           params.tfs_z, params.top_p, params.typical_p, params.temp, params.mirostat, params.mirostat_eta,
           params.mirostat_tau);
-  fprintf(stderr, "generate: n_ctx = %d, tokens_length = %ld, n_batch = %d, n_predict = %d, n_keep = %d\n", n_ctx,
-          embd_inp.size(), params.n_batch, params.n_predict, params.n_keep);
+  fprintf(stderr, "generate: n_ctx = %d, tokens_length = %d, n_batch = %d, n_predict = %d, n_keep = %d\n", n_ctx,
+          static_cast<int>(embd_inp.size()), params.n_batch, params.n_predict, params.n_keep);
   fprintf(stderr, "\n\n");
 
   // TODO(Bo): replace with ring-buffer

--- a/neural_speed/core/layers/bestla_defs.h
+++ b/neural_speed/core/layers/bestla_defs.h
@@ -17,22 +17,21 @@
 #include "bestla/bestla_wrapper.h"
 
 namespace bestla {
-template <class GemmCore_T, template <class, BTLA_ISA> class Wei_T>
-using tLauncher_Fp_F32F32 =
-    wrapper::gemm::LauncherBase<GemmCore_T::ISA, GemmCore_T, prologue_a::gemm::ShuffleActivationKBlockBaseF32, Wei_T,
-                                epilogue::gemm::AccumulatorWriteBackFp32>;
+template <class GemmCore_T, template <class> class Wei_T>
+using tLauncher_Fp_F32F32 = wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ShuffleActivationKBlockBaseF32,
+                                                        Wei_T, epilogue::gemm::AccumulatorWriteBackFp32>;
 
-template <class GemmCore_T, template <class, BTLA_ISA> class Wei_T>
+template <class GemmCore_T, template <class> class Wei_T>
 using tLauncher_Int8_F32F32 =
-    wrapper::gemm::LauncherIntKBlock<GemmCore_T::ISA, GemmCore_T, prologue_a::gemm::ShuffleActivationKBlockQuantizeF32,
-                                     Wei_T, epilogue::gemm::AccumulatorWriteBackFp32>;
+    wrapper::gemm::LauncherIntKBlock<GemmCore_T, prologue_a::gemm::ShuffleActivationKBlockQuantizeF32, Wei_T,
+                                     epilogue::gemm::AccumulatorWriteBackFp32>;
 
 using PcWriteBackF32 = epilogue::gemm::PcKBlockCompInt8Epilogue<epilogue::gemm::AccumulatorWriteBackFp32>;
 
-template <class GemmCore_T, template <class, BTLA_ISA> class Wei_T>
+template <class GemmCore_T, template <class> class Wei_T>
 using tLauncher_Int8Pc_F32F32 =
-    wrapper::gemm::LauncherBase<GemmCore_T::ISA, GemmCore_T, prologue_a::gemm::ShuffleActivationKBlockQuantizeF32,
-                                Wei_T, PcWriteBackF32>;
+    wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ShuffleActivationKBlockQuantizeF32, Wei_T,
+                                PcWriteBackF32>;
 
 using tAVX2 = gemm::SCoreRowNAvx2<24, 4>;
 using tAVX2_VNNI = gemm::ICoreRowNAvx2vnni<24, 4>;
@@ -53,13 +52,13 @@ using tAVX512_VNNI_KBlock = gemm::ICoreRowNAvx512vnniKBlock<48, 4>;
 using tAMX_INT8_US_KBlock = gemm::ICoreRowNAmxint8KBlock<64, 16>;
 using tAMX_INT8_SS_KBlock = gemm::ICoreRowNAmxint8SSKBlock<64, 16>;
 
-template <class GC_T, BTLA_ISA ISA_T>
-using tWeiNInt = prologue_b::gemm::WeightKBlockNInteger<GC_T, ISA_T>;
-template <class GC_T, BTLA_ISA ISA_T>
-using tWeiNFloat = prologue_b::gemm::WeightKBlockNFloat<GC_T, ISA_T>;
+template <class GC_T>
+using tWeiNInt = prologue_b::gemm::WeightKBlockNInteger<GC_T>;
+template <class GC_T>
+using tWeiNFloat = prologue_b::gemm::WeightKBlockNFloat<GC_T>;
 
-template <class GC_T, BTLA_ISA ISA_T>
-using tActKBaseF32 = prologue_a::gemm::ShuffleActivationKBlockBaseF32<GC_T, ISA_T>;
+template <class GC_T>
+using tActKBaseF32 = prologue_a::gemm::ShuffleActivationKBlockBaseF32<GC_T>;
 
 constexpr uint64_t Fp32Cores[] = {tAVX2::ID, tAVX512F::ID};
 constexpr uint64_t Bf16Cores[] = {tAMX_BF16::ID, tAVX512_BF16::ID};

--- a/neural_speed/core/layers/bestla_gemm.cpp
+++ b/neural_speed/core/layers/bestla_gemm.cpp
@@ -31,43 +31,39 @@ Abstract:
 using namespace bestla;  // NOLINT
 
 namespace {
-template <class GemmCore_T, template <class, BTLA_ISA> class Wei_T>
+template <class GemmCore_T, template <class> class Wei_T>
 void BTLAGemmCompF32(const int M, const int N, const int K, const float* A, const int lda,
                      storage::gemm::IWeightBase* _B, float* C, const int ldc, int8_t* WorkSpace,
                      parallel::IThreading* th) {
   using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
-  using Launcher =
-      wrapper::gemm::LauncherBase<GemmCore_T::ISA, GemmCore_T, prologue_a::gemm::ShuffleActivationKBlockBaseF32, Wei_T,
-                                  epilogue::gemm::AccumulatorWriteBackFp32>;
-  static Launcher kernel;
+  using Launcher = wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ShuffleActivationKBlockBaseF32, Wei_T,
+                                               epilogue::gemm::AccumulatorWriteBackFp32>;
   auto B = reinterpret_cast<typename Launcher::PrologueB::StorageWeight*>(_B);
   utils::GemmProblem gp(1, M, N, K, B->mBlockSize);
-  auto reordA = kernel.mProA.createReorderStorage(M, K, B->mBlockSize);
+  auto reordA = Launcher::PrologueA::createReorderStorage(M, K, B->mBlockSize);
   typename Launcher::Param args{gp, {A, K, nullptr, B->ShfIndice(), &reordA}, {B}, {C, N}};
   if (B->ShfIndice()) {
     reordA.assign(WorkSpace);
-    parallel::GemmRunWithA<Parallel>(kernel, args, th);
+    parallel::GemmRunWithA<Parallel, Launcher>(args, th);
   } else {
-    parallel::GemmRun<Parallel>(kernel, args, th);
+    parallel::GemmRun<Parallel, Launcher>(args, th);
   }
 }
 
-template <class GemmCore_T, template <class, BTLA_ISA> class Wei_T>
+template <class GemmCore_T, template <class> class Wei_T>
 void BTLAGemmCompInt8Pc(const int M, const int N, const int K, const float* A, const int lda,
                         storage::gemm::IWeightBase* _B, float* C, const int ldc, int8_t* WorkSpace,
                         parallel::IThreading* th) {
   using Parallel = parallel::gemm::SchedulerBase<GemmCore_T>;
-  using Launcher =
-      wrapper::gemm::LauncherBase<GemmCore_T::ISA, GemmCore_T, prologue_a::gemm::ShuffleActivationKBlockQuantizeF32,
-                                  Wei_T, PcWriteBackF32>;
+  using Launcher = wrapper::gemm::LauncherBase<GemmCore_T, prologue_a::gemm::ShuffleActivationKBlockQuantizeF32, Wei_T,
+                                               PcWriteBackF32>;
   auto B = reinterpret_cast<typename Launcher::PrologueB::StorageWeight*>(_B);
   assert(B->mBlockSize >= K);
   utils::GemmProblem gp(1, M, N, K, B->mBlockSize);
-  static Launcher kernel;
-  auto quanA = kernel.mProA.createQuantStorage(M, K, B->mBlockSize, B->IsAsym());
+  auto quanA = Launcher::PrologueA::createQuantStorage(M, K, B->mBlockSize, B->IsAsym());
   quanA.assign(WorkSpace);
   WorkSpace += quanA.mSize;
-  auto reordA = kernel.mProA.createReorderStorage(M, K, B->mBlockSize);
+  auto reordA = Launcher::PrologueA::createReorderStorage(M, K, B->mBlockSize);
   typename Launcher::Param args{
       gp,
       {A, K, &quanA, B->ShfIndice(), &reordA},
@@ -77,14 +73,14 @@ void BTLAGemmCompInt8Pc(const int M, const int N, const int K, const float* A, c
        {C, N}}};
   if (B->ShfIndice()) {
     reordA.assign(WorkSpace);
-    kernel.mProA.quantize({A, K, &quanA, B->ShfIndice(), &reordA}, M, K, th);
-    parallel::GemmRun<Parallel>(kernel, args, th);
+    Launcher::PrologueA::quantize({A, K, &quanA, B->ShfIndice(), &reordA}, M, K, th);
+    parallel::GemmRun<Parallel, Launcher>(args, th);
   } else {
-    parallel::GemmRunWithA<Parallel>(kernel, args, th);
+    parallel::GemmRunWithA<Parallel, Launcher>(args, th);
   }
 }
 
-template <class GemmCore_T, template <class, BTLA_ISA> class Wei_T>
+template <class GemmCore_T, template <class> class Wei_T>
 void BTLAGemmCompInt8(const int M, const int N, const int K, const float* A, const int lda,
                       storage::gemm::IWeightBase* _B, float* C, const int ldc, int8_t* WorkSpace,
                       parallel::IThreading* th) {
@@ -92,18 +88,17 @@ void BTLAGemmCompInt8(const int M, const int N, const int K, const float* A, con
   using Launcher = tLauncher_Int8_F32F32<GemmCore_T, Wei_T>;
   auto B = reinterpret_cast<typename Launcher::PrologueB::StorageWeight*>(_B);
   utils::GemmProblem gp(1, M, N, K, B->mBlockSize);
-  static Launcher kernel;
-  auto quanA = kernel.mProA.createQuantStorage(M, K, B->mBlockSize, B->IsAsym());
+  auto quanA = Launcher::PrologueA::createQuantStorage(M, K, B->mBlockSize, B->IsAsym());
   quanA.assign(WorkSpace);
   WorkSpace += quanA.mSize;
-  auto reordA = kernel.mProA.createReorderStorage(M, K, B->mBlockSize);
+  auto reordA = Launcher::PrologueA::createReorderStorage(M, K, B->mBlockSize);
   typename Launcher::Param args{gp, {A, K, &quanA, B->ShfIndice(), &reordA}, {B}, {C, N}};
   if (B->ShfIndice()) {
     reordA.assign(WorkSpace);
-    kernel.mProA.quantize({A, K, &quanA, B->ShfIndice(), &reordA}, M, K, th);
-    parallel::GemmRun<Parallel>(kernel, args, th);
+    Launcher::PrologueA::quantize({A, K, &quanA, B->ShfIndice(), &reordA}, M, K, th);
+    parallel::GemmRun<Parallel, Launcher>(args, th);
   } else {
-    parallel::GemmRunWithA<Parallel>(kernel, args, th);
+    parallel::GemmRunWithA<Parallel, Launcher>(args, th);
   }
 }
 
@@ -228,24 +223,23 @@ bool BTLAGemmBatchDriver(const size_t M, const size_t N, const size_t K, const s
 template <typename T>
 size_t BTLABuSize(int block_size, size_t N, size_t K, BTLA_DTYPE QuantType, BTLA_DTYPE ScaleDtype, bool isAsym,
                   int* shuffle_indice) {
-  static T launcher;
   using WType = typename T::PrologueB::StorageWeight;
   WType stor(0);
   if constexpr (std::is_same_v<typename T::PrologueB,
-                               prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore, T::ISA>>) {
-    stor = launcher.mProB.createStorage(N, K, block_size, QuantType, ScaleDtype, BTLA_DTYPE::BF16, isAsym);
+                               prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore>>) {
+    stor = T::PrologueB::createStorage(N, K, block_size, QuantType, ScaleDtype, BTLA_DTYPE::BF16, isAsym);
     if (shuffle_indice != nullptr) {
-      launcher.mProB.enableShuffle(&stor);
+      T::PrologueB::enableShuffle(&stor);
     }
   } else {
-    stor = launcher.mProB.createStorage(N, K, block_size, QuantType, ScaleDtype);
+    stor = T::PrologueB::createStorage(N, K, block_size, QuantType, ScaleDtype);
     (void)(shuffle_indice);
   }
 
   // Reduce dtype set to bf16
   return stor.mSize;
 }
-template <template <class, BTLA_ISA> class Wei_T>
+template <template <class> class Wei_T>
 size_t BTLAGemmPackBSizeLocal(size_t N, size_t K, size_t BlkSize, BTLA_DTYPE QuantType, BTLA_DTYPE ScaleDtype,
                               bool isAsym, ne_comp_type CompType, int* shuffle_indice) {
   GetCPUDevice();
@@ -304,25 +298,24 @@ size_t BTLAGemmPackBSizeLocal(size_t N, size_t K, size_t BlkSize, BTLA_DTYPE Qua
 template <typename T>
 void BTLAGemmQuantPackB(void* PackedBuf, int BlkSize, const float* FpData, int N, int K, BTLA_DTYPE QuantType,
                         BTLA_DTYPE ScaleDtype, bool IsAsym, int ldb, bool IsTrans, void* ThreadPool) {
-  static T launcher;
   using WType = typename T::PrologueB::StorageWeight;
   WType stor(0);
   if constexpr (std::is_same_v<typename T::PrologueB,
-                               prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore, T::ISA>>) {
-    stor = launcher.mProB.createStorage(N, K, BlkSize, QuantType, ScaleDtype, BTLA_DTYPE::BF16, IsAsym);
+                               prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore>>) {
+    stor = T::PrologueB::createStorage(N, K, BlkSize, QuantType, ScaleDtype, BTLA_DTYPE::BF16, IsAsym);
   } else {
-    stor = launcher.mProB.createStorage(N, K, BlkSize, QuantType, ScaleDtype);
+    stor = T::PrologueB::createStorage(N, K, BlkSize, QuantType, ScaleDtype);
   }
   stor.assign(reinterpret_cast<int8_t*>(PackedBuf));
   auto pth = reinterpret_cast<parallel::IThreading*>(ThreadPool);
   if (IsTrans) {
-    launcher.mProB.packTransposeWeight(N, K, FpData, ldb, &stor, pth);
+    T::PrologueB::packTransposeWeight(N, K, FpData, ldb, &stor, pth);
   } else {
-    launcher.mProB.packWeight(N, K, FpData, ldb, &stor, pth);
+    T::PrologueB::packWeight(N, K, FpData, ldb, &stor, pth);
   }
 }
 
-template <template <class, BTLA_ISA> class Wei_T>
+template <template <class> class Wei_T>
 bool BTLAGemmQuantPackBLocal(void* PackedBuf, const float* FpData, size_t N, size_t K, size_t ldb, size_t BlkSize,
                              BTLA_DTYPE QuantType, BTLA_DTYPE ScaleDtype, bool isAsym, ne_comp_type CompType,
                              bool isTrans, void* ThreadPool) {
@@ -398,29 +391,28 @@ template <typename T>
 void BTLAGemmPackBImpl(void* PackedBuf, int BlkSize, const int8_t* QData, const float* Scales, const int8_t* Zp, int N,
                        int K, BTLA_DTYPE QuantType, BTLA_DTYPE ScaleDtype, bool IsAsym, int ldb, int* shuffle_indice,
                        void* ThreadPool) {
-  static T launcher;
   using WType = typename T::PrologueB::StorageWeight;
   auto pth = reinterpret_cast<parallel::IThreading*>(ThreadPool);
   WType stor(0);
   if constexpr (std::is_same_v<typename T::PrologueB,
-                               prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore, T::ISA>>) {
-    stor = launcher.mProB.createStorage(N, K, BlkSize, QuantType, ScaleDtype, BTLA_DTYPE::BF16, IsAsym);
+                               prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore>>) {
+    stor = T::PrologueB::createStorage(N, K, BlkSize, QuantType, ScaleDtype, BTLA_DTYPE::BF16, IsAsym);
     if (shuffle_indice != nullptr) {
-      launcher.mProB.enableShuffle(&stor);
+      T::PrologueB::enableShuffle(&stor);
       stor.assign(reinterpret_cast<int8_t*>(PackedBuf));
-      launcher.mProB.setShuffleIndices(shuffle_indice, &stor, pth);
+      T::PrologueB::setShuffleIndices(shuffle_indice, &stor, pth);
     } else {
       stor.assign(reinterpret_cast<int8_t*>(PackedBuf));
     }
   } else {
     (void)(shuffle_indice);
-    stor = launcher.mProB.createStorage(N, K, BlkSize, QuantType, ScaleDtype);
+    stor = T::PrologueB::createStorage(N, K, BlkSize, QuantType, ScaleDtype);
     stor.assign(reinterpret_cast<int8_t*>(PackedBuf));
   }
-  launcher.mProB.packQWeight(N, K, QData, ldb, Scales, IsAsym ? Zp : nullptr, &stor, pth);
+  T::PrologueB::packQWeight(N, K, QData, ldb, Scales, IsAsym ? Zp : nullptr, &stor, pth);
 }
 
-template <template <class, BTLA_ISA> class Wei_T>
+template <template <class> class Wei_T>
 bool BTLAGemmPackBLocal(void* PackedBuf, const int8_t* QData, const float* Scales, const int8_t* Zp, size_t N, size_t K,
                         size_t ldb, size_t BlkSize, BTLA_DTYPE QuantType, BTLA_DTYPE ScaleDtype, bool isAsym,
                         ne_comp_type CompType, int* shuffle_indice, void* ThreadPool) {
@@ -675,31 +667,31 @@ bool BTLAGemmUnPackB(float* FpData, const void* PackedBuf, size_t N, size_t K, s
       auto sptr = reinterpret_cast<storage::gemm::StorageWeightKBlockNInteger*>(ptr);
       if (btype == gemm::CompType::tFP32 && PackRow == 1) {
         if (NTile == tAVX512F::NTILE && _cd->AVX512F()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAVX512F, tAVX512F::ISA> proB;
+          static prologue_b::gemm::WeightKBlockNInteger<tAVX512F> proB;
           proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         } else if (NTile == tAVX2::NTILE && _cd->AVX2()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAVX2, tAVX2::ISA> proB;
+          static prologue_b::gemm::WeightKBlockNInteger<tAVX2> proB;
           proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         }
       }
       if (btype == gemm::CompType::tS8 && PackRow == 4) {
         if (NTile == tAMX_INT8_US_KBlock::NTILE && _cd->AMX_INT8()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAMX_INT8_US_KBlock, tAMX_INT8_US_KBlock::ISA> proB;
+          static prologue_b::gemm::WeightKBlockNInteger<tAMX_INT8_US_KBlock> proB;
           proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         } else if (NTile == tAVX512_VNNI_KBlock::NTILE && _cd->AVX512_VNNI()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAVX512_VNNI_KBlock, tAVX512_VNNI_KBlock::ISA> proB;
+          static prologue_b::gemm::WeightKBlockNInteger<tAVX512_VNNI_KBlock> proB;
           proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         } else if (NTile == tAVX512BW_KBlock::NTILE && _cd->AVX512BW()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAVX512BW_KBlock, tAVX512BW_KBlock::ISA> proB;
+          static prologue_b::gemm::WeightKBlockNInteger<tAVX512BW_KBlock> proB;
           proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         } else if (NTile == tAVX_VNNI_KBlock::NTILE && _cd->AVX_VNNI()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAVX_VNNI_KBlock, tAVX_VNNI_KBlock::ISA> proB;
+          static prologue_b::gemm::WeightKBlockNInteger<tAVX_VNNI_KBlock> proB;
           proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         }
       }
       if (btype == gemm::CompType::tBF16 && PackRow == 2) {
         if (NTile == tAMX_BF16::NTILE && _cd->AMX_BF16()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAMX_BF16, tAMX_BF16::ISA> proB;
+          static prologue_b::gemm::WeightKBlockNInteger<tAMX_BF16> proB;
           proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         }
       }
@@ -708,16 +700,16 @@ bool BTLAGemmUnPackB(float* FpData, const void* PackedBuf, size_t N, size_t K, s
       auto sptr = reinterpret_cast<storage::gemm::StorageWeightKBlockNFloat*>(ptr);
       if (btype == gemm::CompType::tFP32 && PackRow == 1) {
         if (NTile == tAVX512F::NTILE && _cd->AVX512F()) {
-          static prologue_b::gemm::WeightKBlockNFloat<tAVX512F, tAVX512F::ISA> proB;
+          static prologue_b::gemm::WeightKBlockNFloat<tAVX512F> proB;
           proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         } else if (NTile == tAVX2::NTILE && _cd->AVX2()) {
-          static prologue_b::gemm::WeightKBlockNFloat<tAVX2, tAVX2::ISA> proB;
+          static prologue_b::gemm::WeightKBlockNFloat<tAVX2> proB;
           proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         }
       }
       if (btype == gemm::CompType::tBF16 && PackRow == 2) {
         if (NTile == tAMX_BF16::NTILE && _cd->AMX_BF16()) {
-          static prologue_b::gemm::WeightKBlockNFloat<tAMX_BF16, tAMX_BF16::ISA> proB;
+          static prologue_b::gemm::WeightKBlockNFloat<tAMX_BF16> proB;
           proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         }
       }

--- a/neural_speed/core/layers/bestla_gemm.cpp
+++ b/neural_speed/core/layers/bestla_gemm.cpp
@@ -225,8 +225,7 @@ size_t BTLABuSize(int block_size, size_t N, size_t K, BTLA_DTYPE QuantType, BTLA
                   int* shuffle_indice) {
   using WType = typename T::PrologueB::StorageWeight;
   WType stor(0);
-  if constexpr (std::is_same_v<typename T::PrologueB,
-                               prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore>>) {
+  if constexpr (std::is_same_v<typename T::PrologueB, prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore>>) {
     stor = T::PrologueB::createStorage(N, K, block_size, QuantType, ScaleDtype, BTLA_DTYPE::BF16, isAsym);
     if (shuffle_indice != nullptr) {
       T::PrologueB::enableShuffle(&stor);
@@ -300,8 +299,7 @@ void BTLAGemmQuantPackB(void* PackedBuf, int BlkSize, const float* FpData, int N
                         BTLA_DTYPE ScaleDtype, bool IsAsym, int ldb, bool IsTrans, void* ThreadPool) {
   using WType = typename T::PrologueB::StorageWeight;
   WType stor(0);
-  if constexpr (std::is_same_v<typename T::PrologueB,
-                               prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore>>) {
+  if constexpr (std::is_same_v<typename T::PrologueB, prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore>>) {
     stor = T::PrologueB::createStorage(N, K, BlkSize, QuantType, ScaleDtype, BTLA_DTYPE::BF16, IsAsym);
   } else {
     stor = T::PrologueB::createStorage(N, K, BlkSize, QuantType, ScaleDtype);
@@ -394,8 +392,7 @@ void BTLAGemmPackBImpl(void* PackedBuf, int BlkSize, const int8_t* QData, const 
   using WType = typename T::PrologueB::StorageWeight;
   auto pth = reinterpret_cast<parallel::IThreading*>(ThreadPool);
   WType stor(0);
-  if constexpr (std::is_same_v<typename T::PrologueB,
-                               prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore>>) {
+  if constexpr (std::is_same_v<typename T::PrologueB, prologue_b::gemm::WeightKBlockNInteger<typename T::GemmCore>>) {
     stor = T::PrologueB::createStorage(N, K, BlkSize, QuantType, ScaleDtype, BTLA_DTYPE::BF16, IsAsym);
     if (shuffle_indice != nullptr) {
       T::PrologueB::enableShuffle(&stor);

--- a/neural_speed/core/layers/bestla_gemm.cpp
+++ b/neural_speed/core/layers/bestla_gemm.cpp
@@ -664,32 +664,32 @@ bool BTLAGemmUnPackB(float* FpData, const void* PackedBuf, size_t N, size_t K, s
       auto sptr = reinterpret_cast<storage::gemm::StorageWeightKBlockNInteger*>(ptr);
       if (btype == gemm::CompType::tFP32 && PackRow == 1) {
         if (NTile == tAVX512F::NTILE && _cd->AVX512F()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAVX512F> proB;
-          proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
+          prologue_b::gemm::WeightKBlockNInteger<tAVX512F>::unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr,
+                                                                         FpData, static_cast<int>(ldb), pth);
         } else if (NTile == tAVX2::NTILE && _cd->AVX2()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAVX2> proB;
-          proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
+          prologue_b::gemm::WeightKBlockNInteger<tAVX2>::unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr,
+                                                                      FpData, static_cast<int>(ldb), pth);
         }
       }
       if (btype == gemm::CompType::tS8 && PackRow == 4) {
         if (NTile == tAMX_INT8_US_KBlock::NTILE && _cd->AMX_INT8()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAMX_INT8_US_KBlock> proB;
-          proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
+          prologue_b::gemm::WeightKBlockNInteger<tAMX_INT8_US_KBlock>::unpackWeight(
+              static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         } else if (NTile == tAVX512_VNNI_KBlock::NTILE && _cd->AVX512_VNNI()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAVX512_VNNI_KBlock> proB;
-          proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
+          prologue_b::gemm::WeightKBlockNInteger<tAVX512_VNNI_KBlock>::unpackWeight(
+              static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         } else if (NTile == tAVX512BW_KBlock::NTILE && _cd->AVX512BW()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAVX512BW_KBlock> proB;
-          proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
+          prologue_b::gemm::WeightKBlockNInteger<tAVX512BW_KBlock>::unpackWeight(
+              static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         } else if (NTile == tAVX_VNNI_KBlock::NTILE && _cd->AVX_VNNI()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAVX_VNNI_KBlock> proB;
-          proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
+          prologue_b::gemm::WeightKBlockNInteger<tAVX_VNNI_KBlock>::unpackWeight(
+              static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
         }
       }
       if (btype == gemm::CompType::tBF16 && PackRow == 2) {
         if (NTile == tAMX_BF16::NTILE && _cd->AMX_BF16()) {
-          static prologue_b::gemm::WeightKBlockNInteger<tAMX_BF16> proB;
-          proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
+          prologue_b::gemm::WeightKBlockNInteger<tAMX_BF16>::unpackWeight(static_cast<int>(N), static_cast<int>(K),
+                                                                          sptr, FpData, static_cast<int>(ldb), pth);
         }
       }
     }
@@ -697,17 +697,17 @@ bool BTLAGemmUnPackB(float* FpData, const void* PackedBuf, size_t N, size_t K, s
       auto sptr = reinterpret_cast<storage::gemm::StorageWeightKBlockNFloat*>(ptr);
       if (btype == gemm::CompType::tFP32 && PackRow == 1) {
         if (NTile == tAVX512F::NTILE && _cd->AVX512F()) {
-          static prologue_b::gemm::WeightKBlockNFloat<tAVX512F> proB;
-          proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
+          prologue_b::gemm::WeightKBlockNFloat<tAVX512F>::unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr,
+                                                                       FpData, static_cast<int>(ldb), pth);
         } else if (NTile == tAVX2::NTILE && _cd->AVX2()) {
-          static prologue_b::gemm::WeightKBlockNFloat<tAVX2> proB;
-          proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
+          prologue_b::gemm::WeightKBlockNFloat<tAVX2>::unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr,
+                                                                    FpData, static_cast<int>(ldb), pth);
         }
       }
       if (btype == gemm::CompType::tBF16 && PackRow == 2) {
         if (NTile == tAMX_BF16::NTILE && _cd->AMX_BF16()) {
-          static prologue_b::gemm::WeightKBlockNFloat<tAMX_BF16> proB;
-          proB.unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr, FpData, static_cast<int>(ldb), pth);
+          prologue_b::gemm::WeightKBlockNFloat<tAMX_BF16>::unpackWeight(static_cast<int>(N), static_cast<int>(K), sptr,
+                                                                        FpData, static_cast<int>(ldb), pth);
         }
       }
     }

--- a/neural_speed/models/model_utils/scheduler.cpp
+++ b/neural_speed/models/model_utils/scheduler.cpp
@@ -189,8 +189,8 @@ bool Cont_batch_gen_worker::update_seqs(std::vector<sequence>* seqs, const int& 
     }
     if (!m_ctx->beam_search) {
       if (next_tokens.size() != n_input) {
-        fprintf(stderr, "%s: error: wrong next_tokens size %ld, which should be %d.\n", __func__, next_tokens.size(),
-                n_input);
+        fprintf(stderr, "%s: error: wrong next_tokens size %d, which should be %d.\n", __func__,
+                static_cast<int>(next_tokens.size()), n_input);
         return false;
       }
       seqs->at(ni).generated_ids.emplace_back(next_tokens[ni]);


### PR DESCRIPTION
## Type of Change

Simplify the templates: remove some template parameters.
Use static API instead.
Reduce the compilation time and the binary size.

Compile with GCC 12.2.0 `make ne_layers`
Main branch (before #271) :
`libne_layers.so` compilation time: 10min32s  binary size: 23.6MB

PR branch:
`libne_layers.so` compilation time: 7min34s binary size: 17.0 MB