### PR TITLE
[XeTLA] Sync ipex cb5539e

### DIFF
--- a/include/experimental/kernel/col_major_shuf/col_major_shuf.hpp
+++ b/include/experimental/kernel/col_major_shuf/col_major_shuf.hpp
@@ -20,6 +20,6 @@
 #pragma once
 
 #include <experimental/kernel/col_major_shuf/api.hpp>
+#include <experimental/kernel/col_major_shuf/col_major_shuf_xe.hpp>
 #include <experimental/kernel/col_major_shuf/common.hpp>
 #include <experimental/kernel/col_major_shuf/config.hpp>
-#include <experimental/kernel/col_major_shuf/col_major_shuf_xe.hpp>

--- a/include/experimental/kernel/layer_norm/layer_norm_fwd_xe.hpp
+++ b/include/experimental/kernel/layer_norm/layer_norm_fwd_xe.hpp
@@ -320,7 +320,7 @@ struct layer_norm_fwd_t<
         itr_count += 1;
         nbarrier.wait();
 
-        xetla_vector<dtype_acc, wg_size_x * 2> mu_m2_vec =
+        xetla_vector<dtype_acc, wg_size_x* 2> mu_m2_vec =
             xetla_load_local<dtype_acc, wg_size_x * 2>(slm_load_base);
         xetla_vector<dtype_acc, wg_size_x> mu_vec =
             mu_m2_vec.xetla_select<wg_size_x, 2>(0);

--- a/include/subgroup/tile/impl/payload_xe.hpp
+++ b/include/subgroup/tile/impl/payload_xe.hpp
@@ -84,7 +84,7 @@ struct mem_payload_t<
   xetla_vector<uint32_t, 16 * num_block> payloads;
 
   inline mem_payload_t(const this_payload_t& rhs) {
-    this->payload = rhs.payload;
+    this->payloads = rhs.payloads;
   }
 
   inline mem_payload_t(mem_desc_t& mem_desc) {
@@ -157,7 +157,7 @@ struct mem_payload_t<
   // ~mem_payload_t(){}
 
   inline this_payload_t& operator=(const this_payload_t& rhs) {
-    this->payload = rhs.payload;
+    this->payloads = rhs.payloads;
     return *this;
   }
 
@@ -1725,9 +1725,6 @@ struct prefetch_payload_t<
     this->width_in_elems = rhs.width_in_elems;
     this->height_in_elems = rhs.height_in_elems;
 
-    this->step_x = rhs.step_x;
-    this->step_y = rhs.step_y;
-
     this->channel_offset = rhs.channel_offset;
   }
 
@@ -1742,8 +1739,6 @@ struct prefetch_payload_t<
     this->width_in_elems = rhs.width_in_elems;
     this->height_in_elems = rhs.height_in_elems;
 
-    this->step_x = rhs.step_x;
-    this->step_y = rhs.step_y;
     this->channel_offset = rhs.channel_offset;
     return *this;
   }

--- a/include/subgroup/tile/impl/prefetch_xe.hpp
+++ b/include/subgroup/tile/impl/prefetch_xe.hpp
@@ -150,7 +150,9 @@ tile_prefetch(payload_t& payload) {
   using prefetch_dtype = typename payload_t::prefetch_dtype;
   constexpr uint32_t prefetch_len =
       tile_desc::tile_size_x / payload_t::scale_factor;
-  constexpr uint32_t max_prefetch_in_bytes = load_store_attr_t<msg_type::block_1d, payload_t::arch_tag>::max_prefetch_vec_len;
+  constexpr uint32_t max_prefetch_in_bytes =
+      load_store_attr_t<msg_type::block_1d, payload_t::arch_tag>::
+          max_prefetch_vec_len;
   if constexpr (prefetch_len >= max_prefetch_in_bytes) {
 #pragma unroll
     for (uint32_t j = 0; j < prefetch_len / max_prefetch_in_bytes; j++) {
@@ -165,10 +167,11 @@ tile_prefetch(payload_t& payload) {
     }
   }
   constexpr uint32_t tail_len = prefetch_len % max_prefetch_in_bytes;
-  uint32_t tail_offset =
-      prefetch_len / max_prefetch_in_bytes * max_prefetch_in_bytes * payload_t::scale_factor;
-  detail::process_1d_tail<tail_len, max_prefetch_in_bytes / 2, L1, L2, payload_t>(
-      payload, tail_offset);
+  uint32_t tail_offset = prefetch_len / max_prefetch_in_bytes *
+      max_prefetch_in_bytes * payload_t::scale_factor;
+  detail::
+      process_1d_tail<tail_len, max_prefetch_in_bytes / 2, L1, L2, payload_t>(
+          payload, tail_offset);
 }
 
 /// @brief Is prefetch data func.
@@ -183,8 +186,8 @@ template <
     cache_hint L1 = cache_hint::cached,
     cache_hint L2 = cache_hint::cached,
     typename payload_t>
-__XETLA_API typename std::enable_if_t<
-    detail::check_prefetch_type<payload_t>::is_local>
-tile_prefetch([[maybe_unused]] payload_t& payload) {}
+__XETLA_API
+    typename std::enable_if_t<detail::check_prefetch_type<payload_t>::is_local>
+    tile_prefetch([[maybe_unused]] payload_t& payload) {}
 
 } // namespace gpu::xetla::subgroup


### PR DESCRIPTION
## Type of Change: bug fix
API not changed

## Description

Sync ipex cb5539e

(and `find include -regex '.*\.\(cpp\|hpp\|h\|c\)' -exec clang-format-12 -style=file -i {} \;`)

The result of this PR should match the XeTLA base code of ipex PR 4310

## Expected Behavior & Potential Risk
N/A

## How has this PR been tested?
N/A

## Dependency Change?
N/A
