### PR TITLE
Xetla support 2024.2

### DIFF
--- a/include/common/core/common.hpp
+++ b/include/common/core/common.hpp
@@ -227,16 +227,17 @@ enum class atomic_op : uint8_t {
 
 /// xetla dpas argument typ
 enum class argument_type : uint8_t {
-  U1 = 0, // unsigned 1 bit
-  S1 = 1, // signed 1 bit
-  U2 = 2, // unsigned 2 bits
-  S2 = 3, // signed 2 bits
-  U4 = 4, // unsigned 4 bits
-  S4 = 5, // signed 4 bits
-  U8 = 6, // unsigned 8 bits
-  S8 = 7, // signed 8 bits
-  BF16 = 8, // bfloat 16
-  FP16 = 9, // half float
+  Invalid = 0,
+  U1 __SYCL_DEPRECATED("u1 is reserved/unsupported") = 1, // unsigned 1 bit
+  S1 __SYCL_DEPRECATED("s1 is reserved/unsupported") = 2, // signed 1 bit
+  U2 = 3, // unsigned 2 bits
+  S2 = 4, // signed 2 bits
+  U4 = 5, // unsigned 4 bits
+  S4 = 6, // signed 4 bits
+  U8 = 7, // unsigned 8 bits
+  S8 = 8, // signed 8 bits
+  BF16 = 9, // bfloat 16
+  FP16 = 10, // half float
   TF32 = 12, // tensorfloat 32
   DF = 13, // double (64bits)
   NUM_ARG_TYPES = 14

--- a/include/common/core/common.hpp
+++ b/include/common/core/common.hpp
@@ -228,8 +228,13 @@ enum class atomic_op : uint8_t {
 /// xetla dpas argument typ
 enum class argument_type : uint8_t {
   Invalid = 0,
+#if __INTEL_LLVM_COMPILER >= 20240200
   U1 __SYCL_DEPRECATED("u1 is reserved/unsupported") = 1, // unsigned 1 bit
   S1 __SYCL_DEPRECATED("s1 is reserved/unsupported") = 2, // signed 1 bit
+#else
+  U1 = 1, // unsigned 1 bit
+  S1 = 2, // signed 1 bit
+#endif
   U2 = 3, // unsigned 2 bits
   S2 = 4, // signed 2 bits
   U4 = 5, // unsigned 4 bits

--- a/include/common/core/math_mma.hpp
+++ b/include/common/core/math_mma.hpp
@@ -33,7 +33,11 @@ namespace detail {
 ///
 template <typename dtype>
 constexpr gpu::xetla::argument_type mma_argument_type() {
+#if __INTEL_LLVM_COMPILER < 20240200
   return gpu::xetla::argument_type::U1;
+#else
+  return gpu::xetla::argument_type::U2;
+#endif
 }
 
 template <>
@@ -72,7 +76,11 @@ constexpr gpu::xetla::argument_type mma_argument_type<fp16>() {
 template <gpu::xetla::argument_type arg_type>
 constexpr __ESIMD_NS::xmx::dpas_argument_type get_argument_type() {
   static_assert(
-      arg_type == gpu::xetla::argument_type::U2 ||
+#if __INTEL_LLVM_COMPILER < 20240200
+      arg_type == gpu::xetla::argument_type::U1 ||
+          arg_type == gpu::xetla::argument_type::S1 ||
+#endif
+          arg_type == gpu::xetla::argument_type::U2 ||
           arg_type == gpu::xetla::argument_type::S2 ||
           arg_type == gpu::xetla::argument_type::U4 ||
           arg_type == gpu::xetla::argument_type::S4 ||
@@ -82,7 +90,14 @@ constexpr __ESIMD_NS::xmx::dpas_argument_type get_argument_type() {
           arg_type == gpu::xetla::argument_type::BF16 ||
           arg_type == gpu::xetla::argument_type::TF32,
       "Unsupported argument type");
+
   switch (arg_type) {
+#if __INTEL_LLVM_COMPILER < 20240200
+    case gpu::xetla::argument_type::U1:
+      return __ESIMD_NS::xmx::dpas_argument_type::u1;
+    case gpu::xetla::argument_type::S1:
+      return __ESIMD_NS::xmx::dpas_argument_type::s1;
+#endif
     case gpu::xetla::argument_type::U2:
       return __ESIMD_NS::xmx::dpas_argument_type::u2;
     case gpu::xetla::argument_type::S2:

--- a/include/common/core/memory.hpp
+++ b/include/common/core/memory.hpp
@@ -233,78 +233,110 @@ constexpr __ESIMD_NS::atomic_op get_atomic_op(gpu::xetla::atomic_op ao) {
 }
 } // namespace detail
 
-/// @addtogroup xetla_core_memory
-/// @{
+/// template <typename T, int N, int VS, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// void prefetch(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   simd_mask<N / VS> mask,
+///                   PropertyListT props = {});                   // (usm-pf-1)
+/// void prefetch(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   PropertyListT props = {});                   // (usm-pf-2)
+///
+/// The next 2 functions are similar to the above and were added for
+/// convenience. They assume the VS parameter is set to 1 and do not require
+/// specifying the template parameters <T, N, VS> at function calls.
+/// template <typename T, int N, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// void prefetch(const T *p, simd<OffsetT, N> byte_offsets,
+///                   simd_mask<N> mask,
+///                   PropertyListT props = {});                   // (usm-pf-3)
+/// void prefetch(const T *p, simd<OffsetT, N> byte_offsets,
+///                   PropertyListT props = {});                   // (usm-pf-4)
+/// The next 2 functions are variations of the first 2 above (usm-pf-1,2)
+/// and were added only to support simd_view instead of simd for byte_offsets
+/// operand.
+/// template <typename T, int N, int VS = 1, typename OffsetSimdViewT,
+///           typename PropertyListT = empty_properties_t>
+/// void prefetch(const T *p, OffsetSimdViewT byte_offsets,
+///             simd_mask<N / VS> mask, PropertyListT props = {}); // (usm-pf-5)
+/// void prefetch(const T *p, OffsetSimdViewT byte_offsets,
+///             PropertyListT props = {});                        // (usm-pf-6)
+///
+/// The next functions perform transposed 1-channel prefetch.
+/// template <typename T, int VS = 1, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// void prefetch(const T *p, OffsetT byte_offset, simd_mask<1> mask,
+///                   PropertyListT props = {});                   // (usm-pf-7)
+/// void prefetch(const T *p, OffsetT byte_offset,
+///                   PropertyListT props = {});                   // (usm-pf-8)
+/// template <typename T, int VS = 1,
+///           typename PropertyListT = empty_properties_t>
+/// void prefetch(const T *p, simd_mask<1> mask,
+///                   PropertyListT props = {});                   // (usm-pf-9)
+/// void prefetch(const T *p, PropertyListT props = {});           //(usm-pf-10)
+///
 
-/// @brief Stateless scattered prefetch.
-/// Prefetches elements located at specified address.
-///
-/// Supported platforms: DG2, PVC
-///
-/// VISA instruction: lsc_load.ugm
-///
-/// @tparam Ty is element type.
-/// @tparam NElts is the number of elements to prefetch per address (i.e.
-/// vector_size per SIMD channel).
-/// @tparam DS is the data size.
-/// @tparam L1H is L1 cache hint.
-/// @tparam L2H is L2 cache hint.
-/// @tparam N is the number of SIMD channels (platform dependent).
-/// @param p       [in] is the base pointer.
-/// @param offsets [in] is the zero-based offsets in bytes.
-/// @param pred    [in] is predicates.
-///
+/// template <typename T, int N, int VS, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// void prefetch(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   simd_mask<N / VS> mask,
+///                   PropertyListT props = {});                   // (usm-pf-1)
+/// Supported platforms: DG2, PVC only.
+/// Prefetches elements of the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, to the cache.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the prefetch from
+/// (p + byte_offsets[i]) is skipped.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @tparam VS Vector size. It can also be read as the number of reads per each
+/// address. The parameter 'N' must be divisible by 'VS'.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// @param mask The access mask.
+/// @param props The optional compile-time properties. Only cache hint
+/// properties are used.
 template <
-    typename Ty,
-    int NElts = 1,
-    data_size DS = data_size::default_size,
-    cache_hint L1H = cache_hint::cached,
-    cache_hint L2H = cache_hint::cached,
-    int N>
-__XETLA_API void xetla_prefetch_global(
-    Ty* p,
-    xetla_vector<uint32_t, N> offsets,
-    xetla_mask<N> pred = 1) {
-  using T = native_type_t<Ty>;
-  __ESIMD_ENS::lsc_prefetch<
-      T,
-      NElts,
-      gpu::xetla::detail::get_data_size(DS),
-      gpu::xetla::detail::get_cache_hint(L1H),
-      gpu::xetla::detail::get_cache_hint(L2H),
-      N>((T*)p, offsets, pred);
-}
-
-/// @brief Stateless block prefetch (transposed gather with 1 channel).
-/// Prefetches elements located at specified address.
-///
-/// Supported platforms: DG2, PVC
-///
-/// VISA instruction: lsc_load.ugm
-///
-/// @tparam Ty is element type.
-/// @tparam NElts is the number of elements to prefetch per address (i.e.
-/// vector_size per SIMD channel).
-/// @tparam DS is the data size.
-/// @tparam L1H is L1 cache hint.
-/// @tparam L2H is L2 cache hint.
-/// @param p      [in] is the base pointer.
-/// @param offset [in] is the zero-based offset in bytes.
-///
-template <
-    typename Ty,
-    int NElts = 1,
-    data_size DS = data_size::default_size,
+    typename T,
+    int N,
+    int VS,
     cache_hint L1H = cache_hint::cached,
     cache_hint L2H = cache_hint::cached>
-__XETLA_API void xetla_prefetch_global(Ty* p, uint64_t offset = 0) {
-  using T = native_type_t<Ty>;
-  __ESIMD_ENS::lsc_prefetch<
-      T,
-      NElts,
-      gpu::xetla::detail::get_data_size(DS),
-      gpu::xetla::detail::get_cache_hint(L1H),
-      gpu::xetla::detail::get_cache_hint(L2H)>((T*)p + (offset / sizeof(T)));
+__XETLA_API void xetla_prefetch_global(
+    T* p,
+    xetla_vector<uint32_t, N / VS> byte_offsets,
+    xetla_mask<N / VS> mask = 1) {
+  __ESIMD_NS::properties props{
+      __ESIMD_NS::cache_hint_L1<gpu::xetla::detail::get_cache_hint(L1H)>,
+      __ESIMD_NS::cache_hint_L2<gpu::xetla::detail::get_cache_hint(L2H)>};
+  __ESIMD_NS::prefetch<T, N, VS>(p, byte_offsets, mask, props);
+}
+
+/// template <typename T, int VS = 1, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// void prefetch(const T *p, OffsetT byte_offset,
+///                   PropertyListT props = {});                   // (usm-pf-8)
+/// Supported platforms: DG2, PVC only.
+/// Prefetches elements of the type 'T' from continuous memory location
+/// addressed by the base pointer \p p, and offset \p byte_offset and the length
+/// \p VS elements into the cache.
+/// @tparam T Element type.
+/// @tparam VS Vector size. It specifies the number of consequent elements to
+/// prefetch.
+/// @param p The base address.
+/// @param byte_offset offset from the base address
+/// @param props The optional compile-time properties. Only cache hint
+/// properties are used.
+template <
+    typename T,
+    int VS = 1,
+    cache_hint L1H = cache_hint::cached,
+    cache_hint L2H = cache_hint::cached>
+__XETLA_API void xetla_prefetch_global(T* p, uint64_t offset = 0) {
+  __ESIMD_NS::properties props{
+      __ESIMD_NS::cache_hint_L1<gpu::xetla::detail::get_cache_hint(L1H)>,
+      __ESIMD_NS::cache_hint_L2<gpu::xetla::detail::get_cache_hint(L2H)>};
+  __ESIMD_NS::prefetch<T, VS>(p, offset, props);
 }
 
 /// simd<T, N> block_load(const T* ptr, size_t byte_offset,
@@ -366,90 +398,206 @@ __XETLA_API xetla_vector<T, N> xetla_load_global(
     return __ESIMD_NS::block_load<T, N>(ptr, byte_offset, props);
   }
 }
-
-/// @brief Stateless scattered load.
-/// Collects elements located at specified address and returns them
-/// to a single \ref xetla_vector object.
+/// template <typename T, int N, int VS, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   simd_mask<N / VS> mask, simd<T, N> pass_thru,
+///                   PropertyListT props = {});                   // (usm-ga-1)
+/// simd<T, N> gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   simd_mask<N / VS> mask,
+///                   PropertyListT props = {});                   // (usm-ga-2)
+/// simd<T, N> gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   PropertyListT props = {});                   // (usm-ga-3)
 ///
-/// Supported platforms: DG2, PVC
+/// The next 3 functions are similar to the above and were added for
+/// convenience. They assume the VS parameter is set to 1 and do not require
+/// specifying the template parameters <T, N, VS> at function calls.
+/// template <typename T, int N, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N> byte_offsets,
+///                   simd_mask<N> mask, simd<T, N> pass_thru,
+///                   PropertyListT props = {});                   // (usm-ga-4)
+/// simd<T, N> gather(const T *p, simd<OffsetT, N> byte_offsets,
+///                   simd_mask<N> mask, PropertyListT props = {});// (usm-ga-5)
+/// simd<T, N> gather(const T *p, simd<OffsetT, N> byte_offsets,
+///                   PropertyListT props = {});                   // (usm-ga-6)
 ///
-/// VISA instruction: lsc_load.ugm
-///
-/// @tparam Ty is element type.
-/// @tparam NElts is the number of elements to load per address (i.e.
-/// vector_size per SIMD channel).
-/// @tparam DS is the data size.
-/// @tparam L1H is L1 cache hint.
-/// @tparam L2H is L2 cache hint.
-/// @tparam N is the number of SIMD channels (platform dependent).
-/// @param p       [in] is the base pointer.
-/// @param offsets [in] is the zero-based offsets in bytes.
-/// @param pred    [in] is predicates.
-/// @return  is a xetla_vector of type T and size N * NElts.
-///
+/// The next 3 functions are variations of the first 3 above (usm-ga-1,2,3)
+/// and were added only to support simd_view instead of simd for byte_offsets
+/// and/or pass_thru operands.
+/// template <typename T, int N, int VS = 1, typename OffsetObjT,
+///           typename OffsetRegionT, typename PropertyListT = empty_props_t>
+/// simd <T, N> gather(const T *p,
+///             simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+///             simd_mask<N / VS> mask, simd<T, N> pass_thru,
+///             PropertyListT props = {});                         // (usm-ga-7)
+/// simd <T, N> gather(const T *p,
+///             simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+///             simd_mask<N / VS> mask, PropertyListT props = {}); // (usm-ga-8)
+/// simd <T, N> gather(const T *p,
+///             simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+///             PropertyListT props = {});                         // (usm-ga-9)
+#ifndef __ESIMD_GATHER_SCATTER_LLVM_IR
+/// Supported platforms: DG2, PVC only - Temporary restriction for the variant
+/// with pass_thru operand.
+#endif // __ESIMD_GATHER_SCATTER_LLVM_IR
+/// template <typename T, int N, int VS, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   simd_mask<N / VS> mask, simd<T, N> pass_thru,
+///                   PropertyListT props = {});
+/// Loads ("gathers") elements of the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, and returns
+/// the loaded elements.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the load from
+/// (p + byte_offsets[i]) is skipped and the corresponding i-th element from
+/// \p pass_thru operand is returned.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @tparam VS Vector size. It can also be read as the number of reads per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC and only for 4- and 8-byte element vectors.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// If the alignment property is not passed, then it is assumed that each
+/// accessed address is aligned by element-size.
+/// @param mask The access mask.
+/// @param pass_thru The vector pass through values.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+/// @return A vector of elements read.
 template <
-    typename Ty,
-    int NElts = 1,
-    data_size DS = data_size::default_size,
+    typename T,
+    int N,
+    int VS,
     cache_hint L1H = cache_hint::none,
     cache_hint L2H = cache_hint::none,
-    int N,
-    typename Toffset = uint32_t>
-__XETLA_API xetla_vector<Ty, N * NElts> xetla_load_global(
-    Ty* p,
-    xetla_vector<Toffset, N> offsets,
-    xetla_mask<N> pred = 1) {
-  using T = native_type_t<Ty>;
+    int alignment = 16,
+    typename OffsetT = uint32_t>
+__XETLA_API xetla_vector<T, N> xetla_load_global(
+    T* p,
+    xetla_vector<OffsetT, N / VS> byte_offsets,
+    xetla_mask<N / VS> mask,
+    xetla_vector<T, N> pass_thru) {
+  __ESIMD_NS::properties props{
+      __ESIMD_NS::cache_hint_L1<gpu::xetla::detail::get_cache_hint(L1H)>,
+      __ESIMD_NS::cache_hint_L2<gpu::xetla::detail::get_cache_hint(L2H)>,
+      __ESIMD_NS::alignment<alignment>};
 
-  return __ESIMD_ENS::lsc_gather<
-      T,
-      NElts,
-      gpu::xetla::detail::get_data_size(DS),
-      gpu::xetla::detail::get_cache_hint(L1H),
-      gpu::xetla::detail::get_cache_hint(L2H),
-      N>((T*)p, offsets, pred);
+  return __ESIMD_NS::gather<T, N, VS>(p, byte_offsets, mask, pass_thru, props);
 }
 
-/// @brief Stateless scattered store.
-/// Writes elements to specific address.
-///
-/// Supported platforms: DG2, PVC
-///
-/// VISA instruction: lsc_store.ugm
-///
-/// @tparam Ty is element type.
-/// @tparam NElts is the number of elements to store per address (i.e.
-/// vector_size per SIMD channel).
-/// @tparam DS is the data size.
-/// @tparam L1H is L1 cache hint.
-/// @tparam L2H is L2 cache hint.
-/// @tparam N is the number of SIMD channels (platform dependent).
-/// @param p       [in] is the base pointer.
-/// @param offsets [in] is the zero-based offsets in bytes.
-/// @param vals    [in] is values to store.
-/// @param pred    [in] is predicates.
-///
+/// template <typename T, int N, int VS, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   simd_mask<N / VS> mask,
+///                   PropertyListT props = {});                   // (usm-ga-2)
+/// Loads ("gathers") elements of the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, and returns
+/// the loaded elements.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the load from
+/// (p + byte_offsets[i]) is skipped and the corresponding i-th element of the
+/// returned vector is undefined.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @tparam VS Vector size. It can also be read as the number of reads per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// @param mask The access mask.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+/// @return A vector of elements read. Elements in masked out lanes are
+///   undefined.
 template <
-    typename Ty,
-    int NElts = 1,
-    data_size DS = data_size::default_size,
+    typename T,
+    int N,
+    int VS,
     cache_hint L1H = cache_hint::none,
     cache_hint L2H = cache_hint::none,
+    int alignment = 16,
+    typename OffsetT = uint32_t>
+__XETLA_API xetla_vector<T, N> xetla_load_global(
+    T* p,
+    xetla_vector<OffsetT, N / VS> byte_offsets,
+    xetla_mask<N / VS> mask = 1) {
+  __ESIMD_NS::properties props{
+      __ESIMD_NS::cache_hint_L1<gpu::xetla::detail::get_cache_hint(L1H)>,
+      __ESIMD_NS::cache_hint_L2<gpu::xetla::detail::get_cache_hint(L2H)>,
+      __ESIMD_NS::alignment<alignment>};
+
+  return __ESIMD_NS::gather<T, N, VS>(p, byte_offsets, mask, props);
+}
+
+/// template <typename T, int N, int VS = 1, typename OffsetT,
+/// 	  typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
+/// 	simd_mask<N / VS> mask, PropertyListT props = {}); // (usm-sc-1)
+
+/// template <typename T, int N, int VS = 1, typename OffsetT,
+/// 	  typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
+/// 	PropertyListT props = {});                         // (usm-sc-2)
+
+/// The next two functions are similar to usm-sc-{1,2} with the 'byte_offsets'
+/// parameter represerented as 'simd_view'.
+
+/// template <typename T, int N, int VS = 1, typename OffsetSimdViewT,
+/// 	  typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, OffsetSimdViewT byte_offsets, simd<T, N> vals,
+/// 	simd_mask<N / VS> mask, PropertyListT props = {}); // (usm-sc-3)
+
+/// template <typename T, int N, int VS = 1, typename OffsetSimdViewT,
+/// 	  typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, OffsetSimdViewT byte_offsets, simd<T, N> vals,
+///      PropertyListT props = {});                         // (usm-sc-4)
+
+/// template <typename T, int N, int VS = 1, typename OffsetT,
+/// 	  typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
+/// 	simd_mask<N / VS> mask, PropertyListT props = {}); // (usm-sc-1)
+///
+/// Writes ("scatters") elements of the input vector to different memory
+/// locations. Each memory location is base address plus an offset - a
+/// value of the corresponding element in the input offset vector. Access to
+/// any element's memory location can be disabled via the input mask.
+/// @tparam T Element type.
+/// @tparam N Number of elements to write.
+/// @tparam VS Vector size. It can also be read as the number of writes per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC and only for 4- and 8-byte element vectors.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// If the alignment property is not passed, then it is assumed that each
+/// accessed address is aligned by element-size.
+/// @param vals The vector to scatter.
+/// @param mask The access mask.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+template <
+    typename T,
     int N,
-    typename Toffset = uint32_t>
+    int VS = 1,
+    cache_hint L1H = cache_hint::none,
+    cache_hint L2H = cache_hint::none,
+    int alignment = 16,
+    typename OffsetT = uint32_t>
 __XETLA_API void xetla_store_global(
-    Ty* p,
-    xetla_vector<Toffset, N> offsets,
-    xetla_vector<Ty, N * NElts> vals,
-    xetla_mask<N> pred = 1) {
-  using T = native_type_t<Ty>;
-  __ESIMD_ENS::lsc_scatter<
-      T,
-      NElts,
-      gpu::xetla::detail::get_data_size(DS),
-      gpu::xetla::detail::get_cache_hint(L1H),
-      gpu::xetla::detail::get_cache_hint(L2H),
-      N>((T*)p, offsets, vals, pred);
+    T* p,
+    xetla_vector<OffsetT, N / VS> byte_offsets,
+    xetla_vector<T, N> vals,
+    xetla_mask<N / VS> mask = 1) {
+  __ESIMD_NS::properties props{
+      __ESIMD_NS::cache_hint_L1<gpu::xetla::detail::get_cache_hint(L1H)>,
+      __ESIMD_NS::cache_hint_L2<gpu::xetla::detail::get_cache_hint(L2H)>,
+      __ESIMD_NS::alignment<alignment>};
+  __ESIMD_NS::scatter<T, N, VS>(p, byte_offsets, vals, mask, props);
 }
 
 /// void block_store(T* ptr, size_t byte_offset,         // (usm-bs-2)

--- a/include/experimental/kernel/col_major_shuf/col_major_shuf_xe.hpp
+++ b/include/experimental/kernel/col_major_shuf/col_major_shuf_xe.hpp
@@ -144,11 +144,10 @@ struct col_major_shuf_t<
             block_x * elt_per_block + row * block_size_x) =
             xetla_load_global<
                 dtype_in,
+                block_size_x,
                 1,
-                data_size::default_size,
                 cache_hint::cached,
-                cache_hint::cached,
-                block_size_x>(
+                cache_hint::cached>(
                 args.mat_in_ptr + (y_dim_offset + row) * args.matrix_x,
                 gidx,
                 1);

--- a/include/group/epilogue/impl/stream_k_op_xe.hpp
+++ b/include/group/epilogue/impl/stream_k_op_xe.hpp
@@ -198,7 +198,6 @@ struct epilogue_stream_k_t {
                 atomic_op::cmpxchg,
                 dtype_flag,
                 16,
-                data_size::default_size,
                 cache_hint::uncached,
                 cache_hint::write_back>(
                 flag_pointer, flag_offsets, old_val, zero_val, pred);

--- a/include/group/global_reduction.hpp
+++ b/include/group/global_reduction.hpp
@@ -119,7 +119,6 @@ class global_reduce_t<
         atomic_op::iinc,
         dtype_cnt,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>((dtype_cnt*)address, offsets, pred);
     return ret[0];

--- a/include/subgroup/tile/common.hpp
+++ b/include/subgroup/tile/common.hpp
@@ -104,21 +104,7 @@ template <
 __XETLA_API typename std::enable_if_t<base_len == 0> process_1d_tail(
     [[maybe_unused]] tile_t& tile,
     [[maybe_unused]] payload_t& payload,
-    [[maybe_unused]] uint32_t offset) {}
-
-template <
-    uint32_t remained_len,
-    uint32_t base_len,
-    process_flag flag,
-    cache_hint L1,
-    cache_hint L2,
-    typename payload_t,
-    typename tile_t>
-__XETLA_API typename std::enable_if_t<base_len == 0> process_1d_tail(
-    [[maybe_unused]] tile_t& tile,
-    [[maybe_unused]] payload_t& payload,
-    [[maybe_unused]] uint32_t offset,
-    [[maybe_unused]] uint32_t address_offset) {}
+    [[maybe_unused]] uint32_t byte_offset) {}
 
 template <
     uint32_t remained_len,
@@ -130,26 +116,26 @@ template <
     typename tile_t>
 __XETLA_API typename std::enable_if_t<
     base_len != 0 && payload_t::memory_space == mem_space::global>
-process_1d_tail(tile_t& tile, payload_t& payload, uint32_t offset) {
+process_1d_tail(tile_t& tile, payload_t& payload, uint32_t byte_offset) {
   using dtype = typename payload_t::dtype;
   if constexpr (remained_len >= base_len) {
-    uint32_t address_offset = offset;
-    auto reg_sub = tile.reg.xetla_select<base_len / sizeof(dtype), 1>(offset);
+    auto reg_sub = tile.reg.xetla_select<base_len / sizeof(dtype), 1>(
+        byte_offset / sizeof(dtype));
     if constexpr (flag == process_flag::load) {
       reg_sub.xetla_format<dtype>() =
           xetla_load_global<dtype, base_len / sizeof(dtype), L1, L2>(
-              payload.base_ptr, payload.base_offset + address_offset);
+              payload.base_ptr, payload.base_offset + byte_offset);
     } else {
       xetla_store_global<dtype, base_len / sizeof(dtype), L1, L2>(
           payload.base_ptr,
-          payload.base_offset + address_offset,
+          payload.base_offset + byte_offset,
           reg_sub.xetla_format<dtype>());
     }
     process_1d_tail<remained_len - base_len, (base_len >> 1), flag, L1, L2>(
-        tile, payload, offset + base_len);
+        tile, payload, byte_offset + base_len);
   } else {
     process_1d_tail<remained_len, (base_len >> 1), flag, L1, L2>(
-        tile, payload, offset);
+        tile, payload, byte_offset);
   }
 }
 
@@ -163,20 +149,20 @@ template <
     typename tile_t>
 __XETLA_API typename std::enable_if_t<
     base_len != 0 && payload_t::memory_space == mem_space::local>
-process_1d_tail(tile_t& tile, payload_t& payload, uint32_t offset) {
+process_1d_tail(tile_t& tile, payload_t& payload, uint32_t byte_offset) {
   using dtype = typename payload_t::dtype;
   if constexpr (remained_len >= base_len) {
-    uint32_t address_offset = offset * sizeof(dtype);
-    auto reg_sub = tile.reg.xetla_select<base_len / sizeof(dtype), 1>(offset);
+    auto reg_sub = tile.reg.xetla_select<base_len / sizeof(dtype), 1>(
+        byte_offset / sizeof(dtype));
     if constexpr (flag == process_flag::load) {
       reg_sub.xetla_format<dtype>() = xetla_load_local<
           dtype,
           base_len / sizeof(dtype),
           data_size::default_size>(
-          payload.base_address + payload.address + address_offset);
+          payload.base_address + payload.address + byte_offset);
     } else {
       xetla_store_local<dtype, base_len / sizeof(dtype)>(
-          payload.base_address + payload.address + address_offset,
+          payload.base_address + payload.address + byte_offset,
           reg_sub.xetla_format<dtype>());
     }
     process_1d_tail<
@@ -186,7 +172,7 @@ process_1d_tail(tile_t& tile, payload_t& payload, uint32_t offset) {
         L1,
         L2,
         payload_t,
-        tile_t>(tile, payload, offset + base_len);
+        tile_t>(tile, payload, byte_offset + base_len);
   } else {
     process_1d_tail<
         remained_len,
@@ -195,7 +181,7 @@ process_1d_tail(tile_t& tile, payload_t& payload, uint32_t offset) {
         L1,
         L2,
         payload_t,
-        tile_t>(tile, payload, offset);
+        tile_t>(tile, payload, byte_offset);
   }
 }
 
@@ -210,18 +196,15 @@ template <
     typename payload_t>
 __XETLA_API typename std::enable_if_t<(base_len < 8)> process_1d_tail(
     payload_t& payload,
-    uint32_t offset) {
-  using dtype = typename payload_t::dtype;
+    uint32_t byte_offset) {
   using prefetch_dtype = typename payload_t::prefetch_dtype;
-  uint32_t address_offset = offset * sizeof(dtype);
-  constexpr uint32_t prefetch_min_size = 64 / sizeof(prefetch_dtype);
+  constexpr uint32_t prefetch_min_size = 64;
   if constexpr (remained_len > 0) {
     xetla_prefetch_global<
         prefetch_dtype,
-        prefetch_min_size,
-        data_size::default_size,
+        prefetch_min_size / sizeof(prefetch_dtype),
         L1,
-        L2>(payload.base_ptr, payload.base_offset + address_offset);
+        L2>(payload.base_ptr, payload.base_offset + byte_offset);
   }
 }
 
@@ -233,26 +216,23 @@ template <
     typename payload_t>
 __XETLA_API typename std::enable_if_t<base_len >= 8> process_1d_tail(
     payload_t& payload,
-    uint32_t offset) {
-  using dtype = typename payload_t::dtype;
+    uint32_t byte_offset) {
   using prefetch_dtype = typename payload_t::prefetch_dtype;
   if constexpr (remained_len >= base_len) {
-    uint32_t address_offset = offset * sizeof(dtype);
     xetla_prefetch_global<
         prefetch_dtype,
-        base_len,
-        data_size::default_size,
+        base_len / sizeof(prefetch_dtype),
         L1,
-        L2>(payload.base_ptr, payload.base_offset + address_offset);
+        L2>(payload.base_ptr, payload.base_offset + byte_offset);
     process_1d_tail<
         remained_len - base_len,
         (base_len >> 1),
         L1,
         L2,
-        payload_t>(payload, offset + base_len * payload_t::scale_factor);
+        payload_t>(payload, byte_offset + base_len);
   } else {
     process_1d_tail<remained_len, (base_len >> 1), L1, L2, payload_t>(
-        payload, offset);
+        payload, byte_offset);
   }
 }
 

--- a/include/subgroup/tile/common.hpp
+++ b/include/subgroup/tile/common.hpp
@@ -133,7 +133,7 @@ __XETLA_API typename std::enable_if_t<
 process_1d_tail(tile_t& tile, payload_t& payload, uint32_t offset) {
   using dtype = typename payload_t::dtype;
   if constexpr (remained_len >= base_len) {
-    uint32_t address_offset = offset * sizeof(dtype);
+    uint32_t address_offset = offset;
     auto reg_sub = tile.reg.xetla_select<base_len / sizeof(dtype), 1>(offset);
     if constexpr (flag == process_flag::load) {
       reg_sub.xetla_format<dtype>() =

--- a/include/subgroup/tile/impl/load_xe.hpp
+++ b/include/subgroup/tile/impl/load_xe.hpp
@@ -417,8 +417,9 @@ tile_load(tile_t& tile, payload_t& payload) {
     }
   }
 
-  constexpr uint32_t tail_len = load_len % max_load_vec_elems * sizeof(dtype);
-  uint32_t tail_offset = load_iter_steps * max_load_vec_len;
+  static constexpr uint32_t tail_len =
+      load_len % max_load_vec_elems * sizeof(dtype);
+  static constexpr uint32_t tail_offset = load_iter_steps * max_load_vec_len;
   detail::process_1d_tail<
       tail_len,
       (max_load_vec_len >> 1),

--- a/include/subgroup/tile/impl/load_xe.hpp
+++ b/include/subgroup/tile/impl/load_xe.hpp
@@ -398,8 +398,9 @@ tile_load(tile_t& tile, payload_t& payload) {
       detail::getNextPowerOf2<uint32_t(tile_t::block_elems * sizeof(dtype))>();
 
   using load_store_attr = load_store_attr_t<msg_type::block_1d, arch_tag>;
-  static constexpr uint32_t max_load_vec_len =
-      std::min(power2_block_elems, load_store_attr::max_aligned_load_vec_len);
+  static constexpr uint32_t max_load_vec_len = std::min(
+      uint32_t(tile_t::block_elems * sizeof(dtype)),
+      load_store_attr::max_load_vec_len);
 
   static constexpr uint32_t max_load_vec_elems =
       max_load_vec_len / sizeof(dtype);

--- a/include/subgroup/tile/impl/load_xe.hpp
+++ b/include/subgroup/tile/impl/load_xe.hpp
@@ -418,9 +418,8 @@ tile_load(tile_t& tile, payload_t& payload) {
     }
   }
 
-  static constexpr uint32_t tail_len =
-      load_len % max_load_vec_elems * sizeof(dtype);
-  static constexpr uint32_t tail_offset = load_iter_steps * max_load_vec_len;
+  constexpr uint32_t tail_len = load_len % max_load_vec_elems * sizeof(dtype);
+  uint32_t tail_offset = load_iter_steps * max_load_vec_len;
   detail::process_1d_tail<
       tail_len,
       (max_load_vec_len >> 1),
@@ -457,7 +456,7 @@ tile_load(tile_t& tile, payload_t& payload) {
   using tile_desc = typename payload_t::tile_desc;
   using load_dtype = typename payload_t::mem_dtype;
   constexpr uint32_t num_channel = payload_t::num_channel;
-  constexpr uint32_t load_elems = num_channel * payload_t::simd_exec_size;
+  constexpr uint32_t load_elems = num_channel * payload_t::vector_size;
   constexpr uint32_t pack_factor = payload_t::pack_factor;
 
   auto channel_offset = payload.channel_offset + payload.base_offset;
@@ -474,14 +473,13 @@ tile_load(tile_t& tile, payload_t& payload) {
            (payload_t::mem_transpose ? tile_desc::block_size_x
                                      : tile_desc::block_size_y);
            sub_block_offset += num_channel) {
-        //   uint32_t sub_block_offset = 0;
         xetla_vector<load_dtype, load_elems> reg_tmp = 0;
         uint32_t address_offset = payload_t::mem_transpose
             ? (offset_x + sub_block_offset) * payload.pitch_in_bytes +
                 offset_y * sizeof(dtype)
             : offset_x * sizeof(dtype) +
                 (offset_y + sub_block_offset) * payload.pitch_in_bytes;
-        xetla_mask<num_channel> pred = 1;
+        xetla_mask<num_channel> mask = 1;
         if constexpr (num_channel > 1) {
           // For SDP load, need pred
           const uint32_t sub_block_offset_x = payload.base_x + offset_x +
@@ -493,34 +491,35 @@ tile_load(tile_t& tile, payload_t& payload) {
           const auto size_ch_dim = payload_t::trans ? payload.width_in_elems
                                                     : payload.height_in_elems;
 
-          pred = offset_ch_dim + num_channel > size_ch_dim
+          mask = offset_ch_dim + num_channel > size_ch_dim
               ? (xetla_vector_gen<uint32_t, num_channel>(offset_ch_dim, 1) <
                  size_ch_dim)
               : 1;
         }
         reg_tmp = xetla_load_global<
             load_dtype,
-            payload_t::simd_exec_size,
-            data_size::default_size,
+            load_elems,
+            payload_t::vector_size,
             L1,
-            L2,
-            num_channel>(
-            payload.base_ptr, channel_offset + address_offset, pred);
+            L2>(
+            payload.base_ptr,
+            payload.channel_offset + payload.base_offset + address_offset,
+            mask);
 
         if constexpr (
-            payload_t::simd_exec_size > 1 && payload_t::num_channel > 1) {
+            payload_t::vector_size > 1 && payload_t::num_channel > 1) {
           xetla_vector<load_dtype, load_elems> reg_tmp_trans;
 #pragma unroll
           for (uint32_t iii = 0; iii < payload_t::num_channel; iii++) {
-            if ((bool)pred[iii]) // TODO (dingyi): Delete after driver fix
-              reg_tmp_trans.xetla_select<payload_t::simd_exec_size, 1>(
-                  iii * payload_t::simd_exec_size) =
+            if ((bool)mask[iii]) // TODO (dingyi): Delete after driver fix
+              reg_tmp_trans.xetla_select<payload_t::vector_size, 1>(
+                  iii * payload_t::vector_size) =
                   reg_tmp.xetla_select<
-                      payload_t::simd_exec_size,
+                      payload_t::vector_size,
                       payload_t::num_channel>(iii);
             else // TODO (dingyi): Delete after driver fix
-              reg_tmp_trans.xetla_select<payload_t::simd_exec_size, 1>(
-                  iii * payload_t::simd_exec_size) = 0;
+              reg_tmp_trans.xetla_select<payload_t::vector_size, 1>(
+                  iii * payload_t::vector_size) = 0;
           }
           reg_sub
               .xetla_select<load_elems * pack_factor, 1>(
@@ -687,11 +686,10 @@ tile_load(
 
         reg_tmp = xetla_load_global<
             load_dtype,
+            load_elems,
             1,
-            data_size::default_size,
             L1,
-            L2,
-            load_elems>(
+            L2>(
             payload.base_ptr,
             channel_offset + address_offset,
             pred_x && pred_y);

--- a/include/subgroup/tile/impl/load_xe.hpp
+++ b/include/subgroup/tile/impl/load_xe.hpp
@@ -398,9 +398,8 @@ tile_load(tile_t& tile, payload_t& payload) {
       detail::getNextPowerOf2<uint32_t(tile_t::block_elems * sizeof(dtype))>();
 
   using load_store_attr = load_store_attr_t<msg_type::block_1d, arch_tag>;
-  static constexpr uint32_t max_load_vec_len = std::min(
-      uint32_t(tile_t::block_elems * sizeof(dtype)),
-      load_store_attr::max_load_vec_len);
+  static constexpr uint32_t max_load_vec_len =
+      std::min(power2_block_elems, load_store_attr::max_aligned_load_vec_len);
 
   static constexpr uint32_t max_load_vec_elems =
       max_load_vec_len / sizeof(dtype);
@@ -501,10 +500,7 @@ tile_load(tile_t& tile, payload_t& payload) {
             load_elems,
             payload_t::vector_size,
             L1,
-            L2>(
-            payload.base_ptr,
-            payload.channel_offset + payload.base_offset + address_offset,
-            mask);
+            L2>(payload.base_ptr, channel_offset + address_offset, mask);
 
         if constexpr (
             payload_t::vector_size > 1 && payload_t::num_channel > 1) {
@@ -684,12 +680,7 @@ tile_load(
             : offset_x * sizeof(dtype) +
                 (offset_y + sub_block_y) * payload.pitch_in_bytes;
 
-        reg_tmp = xetla_load_global<
-            load_dtype,
-            load_elems,
-            1,
-            L1,
-            L2>(
+        reg_tmp = xetla_load_global<load_dtype, load_elems, 1, L1, L2>(
             payload.base_ptr,
             channel_offset + address_offset,
             pred_x && pred_y);

--- a/include/subgroup/tile/impl/payload_xe.hpp
+++ b/include/subgroup/tile/impl/payload_xe.hpp
@@ -1116,7 +1116,10 @@ struct mem_payload_t<
   static constexpr uint32_t tile_size_y = tile_desc::tile_size_y;
   static constexpr uint32_t block_size_x = tile_desc::block_size_x;
   static constexpr uint32_t block_size_y = tile_desc::block_size_y;
-
+  static constexpr uint32_t tile_bytes =
+      tile_size_x * tile_size_y * sizeof(dtype);
+  static constexpr uint32_t block_bytes =
+      block_size_x * block_size_y * sizeof(dtype);
   using this_payload_t =
       mem_payload_t<mem_desc_t, tile_desc, msg_type::block_2d, arch_tag_>;
 
@@ -1132,11 +1135,6 @@ struct mem_payload_t<
       (register_layout == reg_layout::vnni_tiled ||
        register_layout == reg_layout::vnni_tiled_col_major);
 
-  static constexpr uint32_t tile_bytes =
-      tile_size_x * tile_size_y * sizeof(dtype);
-  static constexpr uint32_t block_bytes =
-      block_size_x * block_size_y * sizeof(dtype);
-
   static constexpr uint32_t block_per_row_bytes = std::min(
       (mem_transpose ? block_size_y : block_size_x) * uint32_t(sizeof(dtype)),
       alignment_in_bytes);
@@ -1151,10 +1149,9 @@ struct mem_payload_t<
           dtype>::type>::type;
   static constexpr uint32_t pack_factor = sizeof(mem_dtype) / sizeof(dtype);
 
-  static constexpr uint32_t simd_exec_size =
-      (mem_transpose ? block_size_y : block_size_x) >= pack_factor
-      ? (mem_transpose ? block_size_y : block_size_x) / pack_factor
-      : 1;
+  static constexpr uint32_t vector_size =
+      ((mem_transpose ? block_size_y : block_size_x) + pack_factor - 1) /
+      pack_factor;
 
   // for pvc, we can use simd16 or simd32
   using load_store_attr = load_store_attr_t<msg_type::block_1d, arch_tag>;
@@ -1164,7 +1161,7 @@ struct mem_payload_t<
   static constexpr uint32_t max_bytes = std::min(max_load_vec_len, block_bytes);
 
   static constexpr uint32_t max_channel =
-      max_bytes / (simd_exec_size * sizeof(mem_dtype));
+      max_bytes / (vector_size * sizeof(mem_dtype));
 
   static constexpr uint32_t select_channel(const uint32_t channel) {
     return (channel >= load_store_attr::max_channel_num)
@@ -1175,8 +1172,7 @@ struct mem_payload_t<
   }
 
   static constexpr uint32_t num_channel = select_channel(
-      mem_transpose ? std::min(block_size_x, max_channel)
-                    : std::min(block_size_y, max_channel));
+      std::min(mem_transpose ? block_size_x : block_size_y, max_channel));
 
   xetla_vector<uint32_t, num_channel> channel_offset;
   xetla_vector<uint32_t, num_channel> step_x;
@@ -1261,7 +1257,7 @@ struct mem_payload_t<
     base_offset = mem_transpose
         ? base_x * pitch_in_bytes + base_y * sizeof(dtype)
         : base_y * pitch_in_bytes + base_x * sizeof(dtype);
-    base_ptr = (mem_dtype*)p;
+    base_ptr = p;
 
     xetla_vector<uint32_t, num_channel> channel_index =
         xetla_vector_gen<uint32_t, num_channel>(0, 1);
@@ -1659,11 +1655,12 @@ struct prefetch_payload_t<
         reg_layout_>,
     num_coop_sg_,
     arch_tag_,
-    std::enable_if_t<(!arch_has_2d_load_store<arch_tag_>)&&(
-        ((block_size_y_ != 1 || tile_size_y_ != 1) &&
-         mem_layout_ == mem_layout::row_major) ||
-        ((block_size_x_ != 1 || tile_size_x_ != 1) &&
-         mem_layout_ == mem_layout::col_major))>> {
+    std::enable_if_t<
+        (!arch_has_2d_load_store<arch_tag_>) &&
+        (((block_size_y_ != 1 || tile_size_y_ != 1) &&
+          mem_layout_ == mem_layout::row_major) ||
+         ((block_size_x_ != 1 || tile_size_x_ != 1) &&
+          mem_layout_ == mem_layout::col_major))>> {
   using dtype = native_type_t<dtype_>;
   using mem_desc_t =
       mem_desc_t<dtype_, mem_layout_, mem_space::global, alignment_>;
@@ -1723,10 +1720,9 @@ struct prefetch_payload_t<
       : (simd_channel >= block_size_y) ? block_size_y
                                        : simd_channel;
 
-  static constexpr uint32_t simd_exec_size =
-      (mem_transpose ? block_size_y : block_size_x) >= pack_factor
-      ? (mem_transpose ? block_size_y : block_size_x) / pack_factor
-      : 1;
+  static constexpr uint32_t vector_size = mem_transpose
+      ? (block_size_y + pack_factor - 1) / pack_factor
+      : (block_size_x + pack_factor - 1) / pack_factor;
 
   static constexpr uint32_t mem_tile_size_w =
       mem_transpose ? tile_size_y : tile_size_x;
@@ -1906,9 +1902,10 @@ struct prefetch_payload_t<
         reg_layout_>,
     num_coop_sg_,
     arch_tag_,
-    std::enable_if_t<(arch_has_2d_load_store<arch_tag_>)&&(
-        ((tile_size_y_ != 1) && mem_layout_ == mem_layout::row_major) ||
-        ((tile_size_x_ != 1) && mem_layout_ == mem_layout::col_major))>> {
+    std::enable_if_t<
+        (arch_has_2d_load_store<arch_tag_>) &&
+        (((tile_size_y_ != 1) && mem_layout_ == mem_layout::row_major) ||
+         ((tile_size_x_ != 1) && mem_layout_ == mem_layout::col_major))>> {
   using dtype = dtype_;
   using mem_desc_t =
       mem_desc_t<dtype_, mem_layout_, mem_space::global, alignment_>;
@@ -2217,35 +2214,34 @@ struct prefetch_payload_t<
   // CL aligned, so we can use uint64_t
   using prefetch_dtype = uint64_t;
   static constexpr msg_type message_type = msg_type::block_1d;
-  using tile_desc = tile_desc_t<tile_size_x_, 1, block_size_x_, 1, reg_layout_>;
   static constexpr mem_space memory_space = mem_space::global;
   static constexpr mem_layout memory_layout = mem_layout_;
+  static constexpr bool mem_transpose = memory_layout == mem_layout::col_major;
+  using tile_desc = std::conditional_t<
+      mem_transpose,
+      tile_desc_t<1, tile_size_y_, 1, block_size_y_, reg_layout_>,
+      tile_desc_t<tile_size_x_, 1, block_size_x_, 1, reg_layout_>>;
+
   static constexpr gpu_arch arch_tag = arch_tag_;
 
  private:
   // Fetches the entire CL.
-  static constexpr uint32_t cacheline_elems = 64 / sizeof(dtype);
-  static constexpr uint32_t mem_block_nums =
-      (tile_desc::tile_size_x + cacheline_elems - 1) / cacheline_elems;
-  static constexpr uint32_t num_coop_sg = num_coop_sg_;
+  // static constexpr uint32_t cacheline_elems = 64 / sizeof(dtype);
+  // static constexpr uint32_t mem_block_nums =
+  //     (tile_desc::tile_size_x + cacheline_elems - 1) / cacheline_elems;
+  // static constexpr uint32_t num_coop_sg = num_coop_sg_;
 
   // For mem_tile_nums < num_coop_sg cases, mem_tile_size_x will be CL length
   // which might lead to illegal read.
   // there are num_coop_sg threads to prefetch mem_block_nums
   // each thread will prefetch mem_tile_size_x elements
-  static constexpr uint32_t mem_tile_size_x = mem_block_nums > num_coop_sg
-      ? (mem_block_nums + num_coop_sg - 1) / num_coop_sg* cacheline_elems
-      : 0;
+  // static constexpr uint32_t mem_tile_size_x = mem_block_nums > num_coop_sg
+  //     ? (mem_block_nums + num_coop_sg - 1) / num_coop_sg* cacheline_elems
+  //     : 0;
   using this_payload_t =
       prefetch_payload_t<mem_desc_t, tile_desc, num_coop_sg_, arch_tag>;
 
-  // Fixed prefetch_dtype, close this assertion
-  // static_assert(sizeof(prefetch_dtype) >= 4,
-  //         "prefetch dtype size should at least DW aligned");
-
  public:
-  static constexpr uint32_t scale_factor =
-      sizeof(prefetch_dtype) / sizeof(dtype);
   uint32_t base_offset;
   prefetch_dtype* base_ptr;
   uint32_t pitch_in_bytes;
@@ -2265,14 +2261,21 @@ struct prefetch_payload_t<
     return *this;
   }
 
-  inline prefetch_payload_t(mem_desc_t& mem_desc, uint32_t coop_id = 0) {
+  inline prefetch_payload_t(
+      mem_desc_t& mem_desc,
+      [[maybe_unused]] uint32_t coop_id = 0) {
     pitch_in_bytes = mem_desc.shape.stride * sizeof(dtype);
     uint32_t offset_x = mem_desc.coord.x;
     uint32_t offset_y = mem_desc.coord.y;
-    base_offset = offset_y * pitch_in_bytes + offset_x * sizeof(dtype);
-    uint64_t ptr_temp = (uint64_t)mem_desc.base.base;
-    base_ptr =
-        (prefetch_dtype*)ptr_temp + (coop_id % num_coop_sg) * mem_tile_size_x;
+    base_offset = mem_transpose
+        ? offset_x * pitch_in_bytes + offset_y * sizeof(dtype)
+        : offset_y * pitch_in_bytes + offset_x * sizeof(dtype);
+
+    // uint64_t ptr_temp = (uint64_t)mem_desc.base.base;
+    // base_ptr =
+    //     (prefetch_dtype*)ptr_temp + (coop_id % num_coop_sg) *
+    //     mem_tile_size_x;
+    base_ptr = (prefetch_dtype*)mem_desc.base.base;
   }
 
   inline prefetch_payload_t(
@@ -2282,12 +2285,17 @@ struct prefetch_payload_t<
       int surface_pitch,
       int surface_offset_x,
       int surface_offset_y,
-      uint32_t coop_id = 0) {
+      [[maybe_unused]] uint32_t coop_id = 0) {
     pitch_in_bytes = surface_pitch * sizeof(dtype);
     uint32_t offset_x = surface_offset_x;
     uint32_t offset_y = surface_offset_y;
-    base_offset = offset_y * pitch_in_bytes + offset_x * sizeof(dtype);
-    base_ptr = (prefetch_dtype*)p + (coop_id % num_coop_sg) * mem_tile_size_x;
+    base_offset = mem_transpose
+        ? offset_x * pitch_in_bytes + offset_y * sizeof(dtype)
+        : offset_y * pitch_in_bytes + offset_x * sizeof(dtype);
+
+    // base_ptr = (prefetch_dtype*)p + (coop_id % num_coop_sg) *
+    // mem_tile_size_x;
+    base_ptr = (prefetch_dtype*)p;
   }
 
   inline void init(mem_desc_t& mem_desc, uint32_t coop_id = 0) {

--- a/include/subgroup/tile/impl/payload_xe.hpp
+++ b/include/subgroup/tile/impl/payload_xe.hpp
@@ -2226,18 +2226,18 @@ struct prefetch_payload_t<
 
  private:
   // Fetches the entire CL.
-  // static constexpr uint32_t cacheline_elems = 64 / sizeof(dtype);
-  // static constexpr uint32_t mem_block_nums =
-  //     (tile_desc::tile_size_x + cacheline_elems - 1) / cacheline_elems;
-  // static constexpr uint32_t num_coop_sg = num_coop_sg_;
+  static constexpr uint32_t cacheline_elems = 64 / sizeof(dtype);
+  static constexpr uint32_t mem_block_nums =
+      (tile_desc::tile_size_x + cacheline_elems - 1) / cacheline_elems;
+  static constexpr uint32_t num_coop_sg = num_coop_sg_;
 
   // For mem_tile_nums < num_coop_sg cases, mem_tile_size_x will be CL length
   // which might lead to illegal read.
   // there are num_coop_sg threads to prefetch mem_block_nums
   // each thread will prefetch mem_tile_size_x elements
-  // static constexpr uint32_t mem_tile_size_x = mem_block_nums > num_coop_sg
-  //     ? (mem_block_nums + num_coop_sg - 1) / num_coop_sg* cacheline_elems
-  //     : 0;
+  static constexpr uint32_t mem_tile_size_x = mem_block_nums > num_coop_sg
+      ? (mem_block_nums + num_coop_sg - 1) / num_coop_sg* cacheline_elems
+      : 0;
   using this_payload_t =
       prefetch_payload_t<mem_desc_t, tile_desc, num_coop_sg_, arch_tag>;
 

--- a/include/subgroup/tile/impl/store_xe.hpp
+++ b/include/subgroup/tile/impl/store_xe.hpp
@@ -666,13 +666,7 @@ tile_store(
                   sub_block_y * block_size_x),
               pred_x & pred_y);
         } else {
-          xetla_atomic_global<
-              op_kind,
-              dtype,
-              payload_t::num_channel,
-              data_size::default_size,
-              L1,
-              L2>(
+          xetla_atomic_global<op_kind, dtype, payload_t::num_channel, L1, L2>(
               reinterpret_cast<dtype*>(payload.base_pointer + address_offset),
               payload.channel_offset,
               reg_sub.xetla_select<payload_t::store_elems, 1>(

--- a/include/subgroup/tile/impl/store_xe.hpp
+++ b/include/subgroup/tile/impl/store_xe.hpp
@@ -375,13 +375,7 @@ tile_store(
 
         uint32_t address_offset = offset_x * sizeof(dtype) +
             (offset_y + sub_block_y) * payload.pitch_in_bytes;
-        xetla_store_global<
-            store_dtype,
-            1,
-            data_size::default_size,
-            L1,
-            L3,
-            store_elems>(
+        xetla_store_global<store_dtype, store_elems, 1, L1, L3>(
             payload.base_ptr,
             (address_offset + channel_offset),
             reg_sub
@@ -417,13 +411,7 @@ tile_store(
 
         uint32_t address_offset = offset_x * sizeof(dtype) +
             (offset_y + sub_block_y) * payload.pitch_in_bytes;
-        xetla_store_global<
-            store_dtype,
-            1,
-            data_size::default_size,
-            L1,
-            L3,
-            store_elems>(
+        xetla_store_global<store_dtype, store_elems, 1, L1, L3>(
             payload.base_ptr,
             (address_offset + channel_offset),
             reg_sub
@@ -464,7 +452,7 @@ tile_store(tile_t& tile, payload_t& payload) {
   using store_dtype = typename payload_t::mem_dtype;
 
   constexpr uint32_t num_channel = payload_t::num_channel;
-  constexpr uint32_t store_elems = num_channel * payload_t::simd_exec_size;
+  constexpr uint32_t store_elems = num_channel * payload_t::vector_size;
   constexpr uint32_t pack_factor = payload_t::pack_factor;
 
   auto channel_offset = payload.channel_offset + payload.base_offset;
@@ -485,7 +473,7 @@ tile_store(tile_t& tile, payload_t& payload) {
 
         xetla_vector<store_dtype, store_elems> reg_tmp;
 
-        if constexpr (payload_t::simd_exec_size > 1) {
+        if constexpr (payload_t::vector_size > 1) {
           xetla_vector<store_dtype, store_elems> reg_sub_before_trans =
               reg_sub
                   .xetla_select<store_elems * pack_factor, 1>(
@@ -493,11 +481,11 @@ tile_store(tile_t& tile, payload_t& payload) {
                   .xetla_format<store_dtype>();
 #pragma unroll
           for (uint32_t iii = 0; iii < payload_t::num_channel; iii++) {
-            reg_tmp.xetla_select<
-                payload_t::simd_exec_size,
-                payload_t::num_channel>(iii) =
-                reg_sub_before_trans.xetla_select<payload_t::simd_exec_size, 1>(
-                    iii * payload_t::simd_exec_size);
+            reg_tmp
+                .xetla_select<payload_t::vector_size, payload_t::num_channel>(
+                    iii) =
+                reg_sub_before_trans.xetla_select<payload_t::vector_size, 1>(
+                    iii * payload_t::vector_size);
           }
         } else {
           reg_tmp = reg_sub
@@ -513,29 +501,29 @@ tile_store(tile_t& tile, payload_t& payload) {
           xetla_vector<uint32_t, num_channel> channel_index =
               xetla_vector_gen<uint32_t, num_channel>(sub_block_offset_y, 1);
 
-          xetla_mask<num_channel> pred_y =
+          xetla_mask<num_channel> mask =
               channel_index < payload.height_in_elems;
           xetla_store_global<
               store_dtype,
-              payload_t::simd_exec_size,
-              data_size::default_size,
+              store_elems,
+              payload_t::vector_size,
               L1,
-              L3,
-              num_channel>(
+              L3>(
               payload.base_ptr,
               (address_offset + channel_offset),
               reg_tmp,
-              pred_y);
+              mask);
         } else if (
             sub_block_offset_y + num_channel <= payload.height_in_elems) {
           xetla_store_global<
               store_dtype,
-              payload_t::simd_exec_size,
-              data_size::default_size,
+              store_elems,
+              payload_t::vector_size,
               L1,
-              L3,
-              num_channel>(
-              payload.base_ptr, (address_offset + channel_offset), reg_tmp);
+              L3>(
+              payload.base_ptr,
+              (payload.base_offset + address_offset + payload.channel_offset),
+              reg_tmp);
         } else {
           break;
         }

--- a/tests/integration/gemv/int4/main.cpp
+++ b/tests/integration/gemv/int4/main.cpp
@@ -32,7 +32,7 @@ class test_col_major_1 {
  public:
   // Extract the parameters required by different test cases
   static constexpr size_t mat_m = 1;
-  static constexpr size_t mat_n = 11008;
+  static constexpr size_t mat_n = 4096;
   static constexpr size_t mat_k = 4096;
   static constexpr size_t wg_m = 1;
   static constexpr size_t wg_n = 1;

--- a/tests/integration/vector_add/int32_1d/kernel_func.hpp
+++ b/tests/integration/vector_add/int32_1d/kernel_func.hpp
@@ -31,20 +31,11 @@ KERNEL_FUNC inline void vector_add_func(
   offsets *= sizeof(dtype);
   offsets += offset;
   /// use scattered prefetch for a
-  xetla_prefetch_global<
-      dtype,
-      1,
-      data_size::default_size,
-      cache_hint::streaming,
-      cache_hint::cached,
-      SIMD>(a, offsets);
+  xetla_prefetch_global<dtype, SIMD, cache_hint::streaming, cache_hint::cached>(
+      a, offsets);
   /// use block prefetch for b
-  xetla_prefetch_global<
-      dtype,
-      SIMD,
-      data_size::default_size,
-      cache_hint::cached,
-      cache_hint::cached>(b, offset);
+  xetla_prefetch_global<dtype, SIMD, cache_hint::cached, cache_hint::cached>(
+      b, offset);
   SW_BARRIER();
   /// use scattered load for a
   xetla_vector<dtype, SIMD> ivector1 = xetla_load_global<

--- a/tests/integration/vector_add/tf32_1d/kernel_func.hpp
+++ b/tests/integration/vector_add/tf32_1d/kernel_func.hpp
@@ -31,20 +31,11 @@ KERNEL_FUNC inline void vector_add_func(
   offsets *= sizeof(dtype);
   offsets += offset;
   /// use scattered prefetch for a
-  xetla_prefetch_global<
-      dtype,
-      1,
-      data_size::default_size,
-      cache_hint::streaming,
-      cache_hint::cached,
-      SIMD>(a, offsets);
+  xetla_prefetch_global<dtype, SIMD, cache_hint::streaming, cache_hint::cached>(
+      a, offsets);
   /// use block prefetch for b
-  xetla_prefetch_global<
-      dtype,
-      SIMD,
-      data_size::default_size,
-      cache_hint::cached,
-      cache_hint::cached>(b, offset);
+  xetla_prefetch_global<dtype, SIMD, cache_hint::cached, cache_hint::cached>(
+      b, offset);
   SW_BARRIER();
   /// use scattered load for a
   xetla_vector<dtype, SIMD> ivector1 = xetla_load_global<

--- a/tests/unit/global_atomic/kernel_func.hpp
+++ b/tests/unit/global_atomic/kernel_func.hpp
@@ -543,7 +543,8 @@ struct global_atomic_cmpxchg_base {
     offsets *= sizeof(uint32_t);
     offsets += offset;
     xetla_mask<SIMD> pred(1);
-    xetla_vector<uint32_t, SIMD> old_data = xetla_load_global(a, offsets);
+    xetla_vector<uint32_t, SIMD> old_data =
+        xetla_load_global<uint32_t, SIMD, 1>(a, offsets);
     xetla_vector<uint32_t, SIMD> new_data(3);
     xetla_atomic_global<
         atomic_op::cmpxchg,
@@ -569,7 +570,8 @@ struct global_atomic_cmpxchg_mask {
     offsets += offset;
     xetla_mask<SIMD> pred(0);
     pred.xetla_select<4, 1>(0) = 1;
-    xetla_vector<uint32_t, SIMD> old_data = xetla_load_global(a, offsets);
+    xetla_vector<uint32_t, SIMD> old_data =
+        xetla_load_global<uint32_t, SIMD, 1>(a, offsets);
     xetla_vector<uint32_t, SIMD> new_data(3);
     xetla_atomic_global<
         atomic_op::cmpxchg,
@@ -594,7 +596,8 @@ struct global_atomic_cmpxchg_return {
     offsets *= sizeof(uint32_t);
     offsets += offset;
     xetla_mask<SIMD> pred(1);
-    xetla_vector<uint32_t, SIMD> old_data = xetla_load_global(a, offsets);
+    xetla_vector<uint32_t, SIMD> old_data =
+        xetla_load_global<uint32_t, SIMD, 1>(a, offsets);
     xetla_vector<uint32_t, SIMD> new_data(3);
     xetla_vector<uint32_t, SIMD> result = xetla_atomic_global<
         atomic_op::cmpxchg,
@@ -620,7 +623,8 @@ struct global_atomic_fcmpxchg_base {
     offsets *= sizeof(float);
     offsets += offset;
     xetla_mask<SIMD> pred(1);
-    xetla_vector<float, SIMD> old_data = xetla_load_global(a, offsets);
+    xetla_vector<float, SIMD> old_data =
+        xetla_load_global<float, SIMD, 1>(a, offsets);
     xetla_vector<float, SIMD> new_data(3);
     xetla_atomic_global<
         atomic_op::fcmpxchg,

--- a/tests/unit/global_atomic/kernel_func.hpp
+++ b/tests/unit/global_atomic/kernel_func.hpp
@@ -38,7 +38,6 @@ struct global_atomic_iinc_base {
         atomic_op::iinc,
         int,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, pred);
   }
@@ -63,7 +62,6 @@ struct global_atomic_iinc_mask {
         atomic_op::iinc,
         int,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, pred);
   }
@@ -86,7 +84,6 @@ struct global_atomic_iinc_return {
         atomic_op::iinc,
         int,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, pred);
 
@@ -112,7 +109,6 @@ struct global_atomic_idec_base {
         atomic_op::idec,
         int,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, pred);
   }
@@ -136,7 +132,6 @@ struct global_atomic_iadd_base {
         atomic_op::iadd,
         int,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -161,7 +156,6 @@ struct global_atomic_iadd_mask {
         atomic_op::iadd,
         int,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -185,7 +179,6 @@ struct global_atomic_iadd_return {
         atomic_op::iadd,
         int,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
 
@@ -211,7 +204,6 @@ struct global_atomic_isub_base {
         atomic_op::isub,
         int,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -235,7 +227,6 @@ struct global_atomic_smin_base {
         atomic_op::smin,
         int,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -259,7 +250,6 @@ struct global_atomic_smax_base {
         atomic_op::smax,
         int,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -283,7 +273,6 @@ struct global_atomic_fadd_base {
         atomic_op::fadd,
         float,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -307,7 +296,6 @@ struct global_atomic_fsub_base {
         atomic_op::fsub,
         float,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -331,7 +319,6 @@ struct global_atomic_fmin_base {
         atomic_op::fmin,
         float,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -355,7 +342,6 @@ struct global_atomic_fmax_base {
         atomic_op::fmax,
         float,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -379,7 +365,6 @@ struct global_atomic_umin_base {
         atomic_op::umin,
         uint32_t,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -403,7 +388,6 @@ struct global_atomic_umax_base {
         atomic_op::umax,
         uint32_t,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -427,7 +411,6 @@ struct global_atomic_bit_and_base {
         atomic_op::bit_and,
         uint32_t,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -451,7 +434,6 @@ struct global_atomic_bit_or_base {
         atomic_op::bit_or,
         uint32_t,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -475,7 +457,6 @@ struct global_atomic_bit_xor_base {
         atomic_op::bit_xor,
         uint32_t,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, adder, pred);
   }
@@ -498,7 +479,6 @@ struct global_atomic_load {
         atomic_op::load,
         uint32_t,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, pred);
 
@@ -524,7 +504,6 @@ struct global_atomic_store {
         atomic_op::store,
         uint32_t,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, data, pred);
   }
@@ -550,7 +529,6 @@ struct global_atomic_cmpxchg_base {
         atomic_op::cmpxchg,
         uint32_t,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, old_data, new_data, pred);
   }
@@ -577,7 +555,6 @@ struct global_atomic_cmpxchg_mask {
         atomic_op::cmpxchg,
         uint32_t,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, old_data, new_data, pred);
   }
@@ -603,7 +580,6 @@ struct global_atomic_cmpxchg_return {
         atomic_op::cmpxchg,
         uint32_t,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, old_data, new_data, pred);
     xetla_store_global(c, offsets, result);
@@ -630,7 +606,6 @@ struct global_atomic_fcmpxchg_base {
         atomic_op::fcmpxchg,
         float,
         SIMD,
-        data_size::default_size,
         cache_hint::uncached,
         cache_hint::write_back>(a, offsets, old_data, new_data, pred);
   }

--- a/tests/unit/global_load_store/kernel_func.hpp
+++ b/tests/unit/global_load_store/kernel_func.hpp
@@ -57,8 +57,7 @@ struct global_prefetch_block {
       dtype* b,
       [[maybe_unused]] dtype* c) {
     uint64_t offset = 0;
-    xetla_prefetch_global<dtype, SIMD, data_size::default_size, L1, L2>(
-        a, offset);
+    xetla_prefetch_global<dtype, SIMD, L1, L2>(a, offset);
     xetla_vector<dtype, SIMD> A_load_vec =
         xetla_load_global<dtype, SIMD>(a, offset);
     xetla_store_global<dtype, SIMD>(b, offset, A_load_vec);
@@ -108,21 +107,12 @@ struct global_load_scatter_mask {
     pred.xetla_select<4, 1>(0) = 1;
 
     xetla_vector<dtype, SIMD> A_load_vec(0);
-    xetla_vector<dtype, SIMD> tmp = xetla_load_global<
-        dtype,
-        1,
-        data_size::default_size,
-        cache_hint::none,
-        cache_hint::none,
-        SIMD>(a, offsets, pred);
+    xetla_vector<dtype, SIMD> tmp =
+        xetla_load_global<dtype, SIMD, 1, cache_hint::none, cache_hint::none>(
+            a, offsets, pred);
     A_load_vec.xetla_merge(tmp, pred);
-    xetla_store_global<
-        dtype,
-        1,
-        data_size::default_size,
-        cache_hint::none,
-        cache_hint::none,
-        SIMD>(b, offsets, A_load_vec);
+    xetla_store_global<dtype, SIMD, 1, cache_hint::none, cache_hint::none>(
+        b, offsets, A_load_vec);
   }
 };
 
@@ -141,29 +131,19 @@ struct global_prefetch_scatter_mask {
     pred.xetla_select<4, 1>(0) = 1;
     xetla_prefetch_global<
         dtype,
+        SIMD,
         1,
-        data_size::default_size,
         cache_hint::cached,
-        cache_hint::cached,
-        SIMD>(a, offsets, pred);
+        cache_hint::cached>(a, offsets, pred);
 
     xetla_vector<dtype, SIMD> A_load_vec(0);
-    xetla_vector<dtype, SIMD> tmp = xetla_load_global<
-        dtype,
-        1,
-        data_size::default_size,
-        cache_hint::none,
-        cache_hint::none,
-        SIMD>(a, offsets, pred);
+    xetla_vector<dtype, SIMD> tmp =
+        xetla_load_global<dtype, SIMD, 1, cache_hint::none, cache_hint::none>(
+            a, offsets, pred);
     A_load_vec.xetla_merge(tmp, pred);
 
-    xetla_store_global<
-        dtype,
-        1,
-        data_size::default_size,
-        cache_hint::none,
-        cache_hint::none,
-        SIMD>(b, offsets, A_load_vec);
+    xetla_store_global<dtype, SIMD, 1, cache_hint::none, cache_hint::none>(
+        b, offsets, A_load_vec);
   }
 };
 
@@ -185,22 +165,13 @@ struct global_store_scatter_mask {
     pred.xetla_select<4, 1>(0) = 1;
 
     xetla_vector<dtype, SIMD> A_load_vec(0);
-    xetla_vector<dtype, SIMD> tmp = xetla_load_global<
-        dtype,
-        1,
-        data_size::default_size,
-        cache_hint::none,
-        cache_hint::none,
-        SIMD>(a, offsets);
+    xetla_vector<dtype, SIMD> tmp =
+        xetla_load_global<dtype, SIMD, 1, cache_hint::none, cache_hint::none>(
+            a, offsets);
     A_load_vec.xetla_merge(tmp, pred);
 
-    xetla_store_global<
-        dtype,
-        1,
-        data_size::default_size,
-        cache_hint::none,
-        cache_hint::none,
-        SIMD>(b, offsets, A_load_vec, pred);
+    xetla_store_global<dtype, SIMD, 1, cache_hint::none, cache_hint::none>(
+        b, offsets, A_load_vec, pred);
   }
 };
 
@@ -217,17 +188,11 @@ struct global_load_store_scatter_nelt2 {
 
     xetla_vector<dtype, SIMD * 2> A_load_vec = xetla_load_global<
         dtype,
+        SIMD * 2,
         2,
-        data_size::default_size,
         cache_hint::none,
-        cache_hint::none,
-        SIMD>(a, offsets);
-    xetla_store_global<
-        dtype,
-        2,
-        data_size::default_size,
-        cache_hint::none,
-        cache_hint::none,
-        SIMD>(b, offsets, A_load_vec);
+        cache_hint::none>(a, offsets);
+    xetla_store_global<dtype, SIMD * 2, 2, cache_hint::none, cache_hint::none>(
+        b, offsets, A_load_vec);
   }
 };

--- a/tests/unit/local_load_store/kernel_func.hpp
+++ b/tests/unit/local_load_store/kernel_func.hpp
@@ -136,25 +136,19 @@ struct local_load_store_scatter_nelt2 {
         xetla_vector_gen<uint32_t, SIMD>(0, 1);
     offsets = offsets * sizeof(dtype);
 
-    xetla_vector<dtype, SIMD* 2> A_load_vec = xetla_load_global<
+    xetla_vector<dtype, SIMD * 2> A_load_vec = xetla_load_global<
         dtype,
+        SIMD * 2,
         2,
-        data_size::default_size,
         cache_hint::none,
-        cache_hint::none,
-        SIMD>(a, offsets);
+        cache_hint::none>(a, offsets);
 
     xetla_store_local<dtype, 2, data_size::default_size, SIMD>(
         offsets, A_load_vec);
-    xetla_vector<dtype, SIMD* 2> slm_vec =
+    xetla_vector<dtype, SIMD * 2> slm_vec =
         xetla_load_local<dtype, 2, data_size::default_size, SIMD>(offsets);
 
-    xetla_store_global<
-        dtype,
-        2,
-        data_size::default_size,
-        cache_hint::none,
-        cache_hint::none,
-        SIMD>(b, offsets, slm_vec);
+    xetla_store_global<dtype, SIMD * 2, 2, cache_hint::none, cache_hint::none>(
+        b, offsets, slm_vec);
   }
 };

--- a/tests/unit/math_general/kernel_func.hpp
+++ b/tests/unit/math_general/kernel_func.hpp
@@ -33,11 +33,12 @@ struct xetla_abs_vector_version_with_different_input_and_output_types {
     offsets *= sizeof(int);
     offsets += offset;
 
-    xetla_vector<int, SIMD> A_load_vec = xetla_load_global(a, offsets);
+    xetla_vector<int, SIMD> A_load_vec =
+        xetla_load_global<int, SIMD, 1>(a, offsets);
     A_load_vec -= 8;
     xetla_vector<int, SIMD> result =
         xetla_vector<int, SIMD>(xetla_abs<float, int, SIMD>(A_load_vec));
-    xetla_store_global(c, offsets, result);
+    xetla_store_global<int, SIMD, 1>(c, offsets, result);
   }
 };
 
@@ -54,10 +55,11 @@ struct xetla_abs_vector_version_with_same_input_and_output_types {
     offsets *= sizeof(int);
     offsets += offset;
 
-    xetla_vector<int, SIMD> A_load_vec = xetla_load_global(a, offsets);
+    xetla_vector<int, SIMD> A_load_vec =
+        xetla_load_global<int, SIMD, 1>(a, offsets);
     A_load_vec -= 8;
     xetla_vector<int, SIMD> result = xetla_abs<int, SIMD>(A_load_vec);
-    xetla_store_global(c, offsets, result);
+    xetla_store_global<int, SIMD, 1>(c, offsets, result);
   }
 };
 
@@ -96,10 +98,11 @@ struct xetla_max_with_vector_Src0_and_vector_Src1 {
     offsets *= sizeof(int);
     offsets += offset;
 
-    xetla_vector<int, SIMD> A_load_vec = xetla_load_global(a, offsets);
+    xetla_vector<int, SIMD> A_load_vec =
+        xetla_load_global<int, SIMD, 1>(a, offsets);
     xetla_vector<int, SIMD> tmp(8);
     xetla_vector<int, SIMD> result = xetla_max<int, SIMD>(A_load_vec, tmp);
-    xetla_store_global(c, offsets, result);
+    xetla_store_global<int, SIMD, 1>(c, offsets, result);
   }
 };
 
@@ -116,9 +119,10 @@ struct xetla_max_with_vector_Src0_and_scalar_Src1 {
     offsets *= sizeof(int);
     offsets += offset;
 
-    xetla_vector<int, SIMD> A_load_vec = xetla_load_global(a, offsets);
+    xetla_vector<int, SIMD> A_load_vec =
+        xetla_load_global<int, SIMD, 1>(a, offsets);
     xetla_vector<int, SIMD> result = xetla_max<int, SIMD>(A_load_vec, 8);
-    xetla_store_global(c, offsets, result);
+    xetla_store_global<int, SIMD, 1>(c, offsets, result);
   }
 };
 
@@ -135,9 +139,10 @@ struct xetla_max_with_scalar_Src0_and_vector_Src1 {
     offsets *= sizeof(int);
     offsets += offset;
 
-    xetla_vector<int, SIMD> A_load_vec = xetla_load_global(a, offsets);
+    xetla_vector<int, SIMD> A_load_vec =
+        xetla_load_global<int, SIMD, 1>(a, offsets);
     xetla_vector<int, SIMD> result = xetla_max<int, SIMD>(8, A_load_vec);
-    xetla_store_global(c, offsets, result);
+    xetla_store_global<int, SIMD, 1>(c, offsets, result);
   }
 };
 
@@ -165,10 +170,11 @@ struct xetla_min_with_vector_Src0_and_vector_Src1 {
     offsets *= sizeof(int);
     offsets += offset;
 
-    xetla_vector<int, SIMD> A_load_vec = xetla_load_global(a, offsets);
+    xetla_vector<int, SIMD> A_load_vec =
+        xetla_load_global<int, SIMD, 1>(a, offsets);
     xetla_vector<int, SIMD> tmp(8);
     xetla_vector<int, SIMD> result = xetla_min<int, SIMD>(A_load_vec, tmp);
-    xetla_store_global(c, offsets, result);
+    xetla_store_global<int, SIMD, 1>(c, offsets, result);
   }
 };
 
@@ -185,9 +191,10 @@ struct xetla_min_with_vector_Src0_and_scalar_Src1 {
     offsets *= sizeof(int);
     offsets += offset;
 
-    xetla_vector<int, SIMD> A_load_vec = xetla_load_global(a, offsets);
+    xetla_vector<int, SIMD> A_load_vec =
+        xetla_load_global<int, SIMD, 1>(a, offsets);
     xetla_vector<int, SIMD> result = xetla_min<int, SIMD>(A_load_vec, 8);
-    xetla_store_global(c, offsets, result);
+    xetla_store_global<int, SIMD, 1>(c, offsets, result);
   }
 };
 
@@ -204,9 +211,10 @@ struct xetla_min_with_scalar_Src0_and_vector_Src1 {
     offsets *= sizeof(int);
     offsets += offset;
 
-    xetla_vector<int, SIMD> A_load_vec = xetla_load_global(a, offsets);
+    xetla_vector<int, SIMD> A_load_vec =
+        xetla_load_global<int, SIMD, 1>(a, offsets);
     xetla_vector<int, SIMD> result = xetla_min<int, SIMD>(8, A_load_vec);
-    xetla_store_global(c, offsets, result);
+    xetla_store_global<int, SIMD, 1>(c, offsets, result);
   }
 };
 

--- a/tests/unit/named_barrier/kernel_func.hpp
+++ b/tests/unit/named_barrier/kernel_func.hpp
@@ -38,10 +38,11 @@ struct named_barrier_func {
 #pragma unroll
     for (size_t i = 0; i < 16; i++) {
       if (item->get_local_id(0) == i) {
-        xetla_vector<dtype, SIMD> A_load_vec = xetla_load_global(a, offsets);
+        xetla_vector<dtype, SIMD> A_load_vec =
+            xetla_load_global<dtype, SIMD, 1>(a, offsets);
         xetla_vector<dtype, SIMD> Dst = A_load_vec * 2;
-        xetla_store_global(c, offsets, A_load_vec);
-        xetla_store_global(a, offsets, Dst);
+        xetla_store_global<dtype, SIMD, 1>(c, offsets, A_load_vec);
+        xetla_store_global<dtype, SIMD, 1>(a, offsets, Dst);
       }
       nbarrier.arrive();
       nbarrier.wait();

--- a/tests/unit/raw_send/kernel_func.hpp
+++ b/tests/unit/raw_send/kernel_func.hpp
@@ -34,7 +34,8 @@ struct raw_send_with_2_source_and_1_destination_func {
     offsets += offset;
     xetla_vector<uint64_t, SIMD> dsec = offsets + (uint64_t)a;
 
-    xetla_vector<dtype, SIMD> A_load_vec = xetla_load_global(a, offsets);
+    xetla_vector<dtype, SIMD> A_load_vec =
+        xetla_load_global<dtype, SIMD, 1>(a, offsets);
     xetla_vector<dtype, SIMD> Dst = A_load_vec;
 
     constexpr uint32_t size = SIMD * sizeof(dtype) / 64;


### PR DESCRIPTION
## Type of Change

feature or bug fix or documentation or others  --   Update compiler API to 2024.2
API changed or not  --  Not

## Description
1 Update prefetch 1D API
2 Update atomic API
3 Update gather/scatter API
4 Update 1 fp16 load/store
5 Unify all length units to bytes instead of elems(common.hpp)

2D load/store/prefetch not updated, will be updated in subsequent PR

detail description 
Issues: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
