### PR TITLE
XeTLA Zero-Passthrough

### DIFF
--- a/include/subgroup/tile/impl/payload_xe.hpp
+++ b/include/subgroup/tile/impl/payload_xe.hpp
@@ -1655,12 +1655,11 @@ struct prefetch_payload_t<
         reg_layout_>,
     num_coop_sg_,
     arch_tag_,
-    std::enable_if_t<
-        (!arch_has_2d_load_store<arch_tag_>) &&
-        (((block_size_y_ != 1 || tile_size_y_ != 1) &&
-          mem_layout_ == mem_layout::row_major) ||
-         ((block_size_x_ != 1 || tile_size_x_ != 1) &&
-          mem_layout_ == mem_layout::col_major))>> {
+    std::enable_if_t<(!arch_has_2d_load_store<arch_tag_>)&&(
+        ((block_size_y_ != 1 || tile_size_y_ != 1) &&
+         mem_layout_ == mem_layout::row_major) ||
+        ((block_size_x_ != 1 || tile_size_x_ != 1) &&
+         mem_layout_ == mem_layout::col_major))>> {
   using dtype = native_type_t<dtype_>;
   using mem_desc_t =
       mem_desc_t<dtype_, mem_layout_, mem_space::global, alignment_>;
@@ -1902,10 +1901,9 @@ struct prefetch_payload_t<
         reg_layout_>,
     num_coop_sg_,
     arch_tag_,
-    std::enable_if_t<
-        (arch_has_2d_load_store<arch_tag_>) &&
-        (((tile_size_y_ != 1) && mem_layout_ == mem_layout::row_major) ||
-         ((tile_size_x_ != 1) && mem_layout_ == mem_layout::col_major))>> {
+    std::enable_if_t<(arch_has_2d_load_store<arch_tag_>)&&(
+        ((tile_size_y_ != 1) && mem_layout_ == mem_layout::row_major) ||
+        ((tile_size_x_ != 1) && mem_layout_ == mem_layout::col_major))>> {
   using dtype = dtype_;
   using mem_desc_t =
       mem_desc_t<dtype_, mem_layout_, mem_space::global, alignment_>;

--- a/tests/integration/fmha/fmha_forward.hpp
+++ b/tests/integration/fmha/fmha_forward.hpp
@@ -129,12 +129,12 @@ class fmha_forward_t {
   using comp_attr = group::compute_attr_t<scalar_t, scalar_t, accum_t>;
   using knobs = group::perf_tuning_knob_t<accum_step, stages, sync_freq>;
   using compute_policy_BrBc = std::conditional_t<
-      (arch_tag >= gpu_arch::XeHpg),
+      (arch_has_xmx<arch_tag>),
       group::compute_policy_default_xmx<comp_attr, knobs, arch_tag>,
       group::compute_policy_default_fpu<comp_attr, knobs, arch_tag>>;
   // TODO: add k slicing
   using compute_policy_BrBm = std::conditional_t<
-      (arch_tag >= gpu_arch::XeHpg),
+      (arch_has_xmx<arch_tag>),
       group::compute_policy_default_xmx<comp_attr, knobs, arch_tag>,
       group::compute_policy_default_fpu<comp_attr, knobs, arch_tag>>;
   // ---------------- // Tile shape and Threads // ---------------- //
@@ -688,7 +688,7 @@ class fmha_forward_t {
                     uint8_t,
                     mem_desc_Dp_Mask_t::layout,
                     mem_desc_Dp_Mask_t::space>>,
-            gpu_arch::XeHpc>;
+            arch_tag>;
         load_payload_mask_t load_payload_mask(ctx.mem_desc_Dpij);
         subgroup::tile_load(mask_in, load_payload_mask);
         matAccSij.reg = matAccSij.reg * mask_in.reg * args.dp_scale;
@@ -771,7 +771,7 @@ class fmha_forward_t {
     uint32_t height = args.uB * args.uN * args.uF;
     uint32_t offset_height = b * args.uN * args.uF + f * args.uN + n;
 
-    if constexpr (arch_tag != gpu_arch::XeHpc) {
+    if constexpr (!arch_has_2d_load_store<arch_tag>) {
       // offset for curr work item
       const uint32_t O_offset = offset_height * args.uH + h;
       const auto ld_c = args.uN * args.uH;
@@ -798,30 +798,30 @@ class fmha_forward_t {
       matOi_store_t matOi_store(mem_desc_Oi);
       subgroup::tile_store<cache_hint::write_back, cache_hint::write_back>(
           matOi, matOi_store);
-      return;
-    }
+    } else {
+      xetla_fill_tdesc<scalar_t, kSgHm, 1, 1>(
+          transpose_tdecs.xetla_format<uint32_t>(),
+          args.O_ptr,
+          args.uH,
+          height,
+          args.uH,
+          h,
+          offset_height);
 
-    xetla_fill_tdesc<scalar_t, kSgHm, 1, 1>(
-        transpose_tdecs.xetla_format<uint32_t>(),
-        args.O_ptr,
-        args.uH,
-        height,
-        args.uH,
-        h,
-        offset_height);
+      for (uint32_t i = 0; i < kSgBr && (f + i < args.uF); ++i) {
+        // load data from matAccOi
+        auto v_acc = matAccOi.reg.xetla_select<kSgHm, 1>(i * kSgHm);
+        v_out = xetla_cvt<scalar_t, accum_t, kSgHm>(v_acc);
 
-    for (uint32_t i = 0; i < kSgBr && (f + i < args.uF); ++i) {
-      // load data from matAccOi
-      auto v_acc = matAccOi.reg.xetla_select<kSgHm, 1>(i * kSgHm);
-      v_out = xetla_cvt<scalar_t, accum_t, kSgHm>(v_acc);
-
-      xetla_tstore_global<
-          scalar_t,
-          kSgHm,
-          cache_hint::write_back,
-          cache_hint::write_back>(transpose_tdecs, v_out);
-      xetla_update_tdesc_offsety(
-          transpose_tdecs.xetla_format<uint32_t>(), args.uN);
+        xetla_tstore_global<
+            scalar_t,
+            kSgHm,
+            cache_hint::write_back,
+            cache_hint::write_back,
+            arch_tag>(transpose_tdecs, v_out);
+        xetla_update_tdesc_offsety(
+            transpose_tdecs.xetla_format<uint32_t>(), args.uN);
+      }
     }
   }
   // ====================== // preload_Qi // ====================== //
@@ -888,16 +888,9 @@ class fmha_forward_t {
   /// @return The size of local memory required.
   inline static constexpr uint32_t get_slm_size() {
     constexpr uint32_t size = slm_size_Qi + slm_size_Pij + slm_size_softmax;
-    if constexpr (arch_tag == gpu_arch::XeHpc) {
-      static_assert(
-          size <= (128 * 1024),
-          "The local memory size should be less than 128KB!");
-
-    } else {
-      static_assert(
-          size <= (64 * 1024),
-          "The local memory size should be less than 64KB!");
-    }
+    static_assert(
+        size <= (arch_attr_t<arch_tag>::local_mem_size),
+        "The local memory size should be less than arch total local memory size");
     return size;
   };
 

--- a/tests/integration/fmha/fmha_utils.h
+++ b/tests/integration/fmha/fmha_utils.h
@@ -134,7 +134,7 @@ template <
     typename mat_t,
     uint32_t kNumSg,
     reduce_op reduce_kind,
-    gpu_arch arch_tag = gpu_arch::XeHpc>
+    gpu_arch arch_tag>
 struct group_row_reduce_t {
   using T = typename mat_t::dtype;
   static constexpr uint32_t kNum = mat_t::tile_desc::tile_size_y;
@@ -215,7 +215,7 @@ enum class add_type : uint8_t {
 /// @tparam arch_tag Is the hardware architecture tag.
 template <
     typename dtype_bias_,
-    gpu_arch arch_tag = gpu_arch::XeHpc,
+    gpu_arch arch_tag,
     add_type add_tag = add_type::single_line>
 struct bias_add_op_t {};
 
@@ -324,8 +324,8 @@ struct bias_add_op_t<dtype_bias_, arch_tag, add_type::single_element> {
   using base_t = typename mem_desc_bias_t::base_t;
 
   struct arguments_t {
-    shape_t shape;
     base_t base;
+    shape_t shape;
     inline arguments_t() = default;
     inline arguments_t(base_t base_, shape_t shape_)
         : base(base_), shape(shape_) {}
@@ -351,11 +351,10 @@ struct bias_add_op_t<dtype_bias_, arch_tag, add_type::single_element> {
     uint32_t offset = (pos_y + pos_x * args.shape.stride) * sizeof(dtype_bias);
     auto bias_data_vector = xetla_load_global<
         dtype_bias,
+        16,
         1,
-        data_size::default_size,
         cache_hint::cached,
-        cache_hint::cached,
-        16>(ptr, offset);
+        cache_hint::cached>(ptr, offset);
     dtype_acc bias_data =
         xetla_cvt<dtype_acc, dtype_bias, 16>(bias_data_vector)[0];
 
@@ -418,15 +417,19 @@ template <
     typename mem_desc_c_t_>
 class epilogue_transp_t {};
 
-template <typename tile_op_t_, typename tile_shape_, typename mem_desc_c_t_>
+template <
+    typename tile_op_t_,
+    typename tile_shape_,
+    typename mem_desc_c_t_,
+    gpu_arch arch_tag_>
 class epilogue_transp_t<
-    epilogue_policy_tile_op<tile_op_t_, gpu_arch::XeHpc>,
+    epilogue_policy_tile_op<tile_op_t_, arch_tag_>,
     tile_shape_,
     mem_desc_c_t_> {
  public:
   using tile_shape = tile_shape_;
   using mem_desc_c_t = mem_desc_c_t_;
-  static constexpr gpu_arch arch_tag = gpu_arch::XeHpc;
+  static constexpr gpu_arch arch_tag = arch_tag_;
   static constexpr uint32_t barrier_count = 0;
   static constexpr uint32_t slm_size = 0;
 
@@ -505,7 +508,7 @@ class epilogue_write_back_t<
     epilogue_policy_default<arch_tag_>,
     tile_shape_,
     mem_desc_c_t_,
-    std::enable_if_t<((arch_tag_ <= gpu_arch::XeHpc))>> {
+    std::enable_if_t<valid_xe_arch_tag<arch_tag_>>> {
  public:
   using epilogue_policy = epilogue_policy_default<arch_tag_>;
   using tile_shape = tile_shape_;


### PR DESCRIPTION
## Type of Change: Feature
API not changed

## Description
Previously there is a bug with the mask load, so we have to achieve accuracy with extra overhead. This overhead will be removed in this PR.

## Expected Behavior & Potential Risk
N/A

## How has this PR been tested?
Internal IPEX CI

### Performance on MTL
`xetla` barnch
```
[ RUN      ] XeTLA/FMHATest.kUseBiasOFF_kSeqLastOFF_bs1_hn32_hs128_qlen1_klen33
[kernel time]The maximum gflops(GPU_time) is 9.90242
[ RUN      ] XeTLA/FMHATest.kUseBiasOFF_kSeqLastON_bs1_hn32_hs128_qlen1_klen33
[kernel time]The maximum gflops(GPU_time) is 10.4184
[ RUN      ] XeTLA/FMHATest.kUseBiasON_kSeqLastOFF_bs1_hn32_hs128_qlen1_klen33
[kernel time]The maximum gflops(GPU_time) is 10.3561
[ RUN      ] XeTLA/FMHATest.kUseBiasON_kSeqLastON_bs1_hn32_hs128_qlen1_klen33
[kernel time]The maximum gflops(GPU_time) is 10.5452
[ RUN      ] XeTLA/FMHATest.kUseBiasOFF_kSeqLastOFF_bs1_hn32_hs128_qlen1_klen1023
[kernel time]The maximum gflops(GPU_time) is 51.7042
[ RUN      ] XeTLA/FMHATest.kUseBiasOFF_kSeqLastON_bs1_hn32_hs128_qlen1_klen1023
[kernel time]The maximum gflops(GPU_time) is 49.3453
[ RUN      ] XeTLA/FMHATest.kUseBiasON_kSeqLastOFF_bs1_hn32_hs128_qlen1_klen1023
[kernel time]The maximum gflops(GPU_time) is 49.573
[ RUN      ] XeTLA/FMHATest.kUseBiasON_kSeqLastON_bs1_hn32_hs128_qlen1_klen1023
[kernel time]The maximum gflops(GPU_time) is 52.3423
```
This PR
```
[ RUN      ] XeTLA/FMHATest.kUseBiasOFF_kSeqLastOFF_bs1_hn32_hs128_qlen1_klen33
[kernel time]The maximum gflops(GPU_time) is 12.8365
[ RUN      ] XeTLA/FMHATest.kUseBiasOFF_kSeqLastON_bs1_hn32_hs128_qlen1_klen33
[kernel time]The maximum gflops(GPU_time) is 10.3975
[ RUN      ] XeTLA/FMHATest.kUseBiasON_kSeqLastOFF_bs1_hn32_hs128_qlen1_klen33
[kernel time]The maximum gflops(GPU_time) is 11.3263
[ RUN      ] XeTLA/FMHATest.kUseBiasON_kSeqLastON_bs1_hn32_hs128_qlen1_klen33
[kernel time]The maximum gflops(GPU_time) is 10.0362
[ RUN      ] XeTLA/FMHATest.kUseBiasOFF_kSeqLastOFF_bs1_hn32_hs128_qlen1_klen1023
[kernel time]The maximum gflops(GPU_time) is 56.154
[ RUN      ] XeTLA/FMHATest.kUseBiasOFF_kSeqLastON_bs1_hn32_hs128_qlen1_klen1023
[kernel time]The maximum gflops(GPU_time) is 58.3497
[ RUN      ] XeTLA/FMHATest.kUseBiasON_kSeqLastOFF_bs1_hn32_hs128_qlen1_klen1023
[kernel time]The maximum gflops(GPU_time) is 55.4583
[ RUN      ] XeTLA/FMHATest.kUseBiasON_kSeqLastON_bs1_hn32_hs128_qlen1_klen1023
[kernel time]The maximum gflops(GPU_time) is 58.2443
```


## Dependency Change?
No
